### PR TITLE
Fix issue where NSwag Studio generated output uses the cached Swagger JSON spec

### DIFF
--- a/src/ApiClientCodeGen.VSIX/Generators/NSwagStudio/NSwagStudioCodeGenerator.cs
+++ b/src/ApiClientCodeGen.VSIX/Generators/NSwagStudio/NSwagStudioCodeGenerator.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Extensions;
 using Microsoft.VisualStudio.Shell.Interop;
+using Newtonsoft.Json;
 
 namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Generators.NSwagStudio
 {
@@ -26,9 +28,26 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Generators.NSwa
             if (!File.Exists(command))
                 throw new NotInstalledException("NSwag not installed. Please install NSwagStudio");
 
+            TryRemoveSwaggerJsonSpec();
             ProcessHelper.StartProcess(command, $"run \"{nswagStudioFile}\"");
             pGenerateProgress?.Progress(90);
             return null;
+        }
+
+        private void TryRemoveSwaggerJsonSpec()
+        {
+            try
+            {
+                var json = File.ReadAllText(nswagStudioFile);
+                dynamic obj = JsonConvert.DeserializeObject(json);
+                obj.swaggerGenerator.fromSwagger.json = null;
+                json = JsonConvert.SerializeObject(obj);
+                File.WriteAllText(nswagStudioFile, json);
+            }
+            catch (Exception e)
+            {
+                Trace.WriteLine(e);
+            }
         }
     }
 }


### PR DESCRIPTION
Try to remove the cached Swagger.json spec contained in the NSwag Studio file