### PR TITLE
OpenAPI Generator v4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ A collection of Visual Studio C# custom tool code generators for Swagger / OpenA
 **Features**
 
 - Supports Visual Studio 2017 and 2019
-- Add New REST API Client to a project from an OpenAPI specification URL (e.g https://petstore.swagger.io/v2/swagger.json) using **AutoRest**, **NSwag**, **Swagger Codegen**, or **OpenAPI Codegen**
+- Add New REST API Client to a project from an OpenAPI specification URL (e.g https://petstore.swagger.io/v2/swagger.json) using [AutoRest](https://github.com/Azure/autorest), [NSwag](https://github.com/RicoSuter/NSwag), [Swagger Codegen](https://github.com/swagger-api/swagger-codegen), or [OpenAPI Generator](https://github.com/OpenAPITools/openapi-generator)
 - Define custom namespace for the generated file
 - Auto-updating of generated code file when changes are made to the OpenAPI specification json file (Swagger.json)
-- Generate code using an NSwag Studio file by including it in the project and using the **Generate with NSwag Studio** context menu
+- Generate code using an [NSwag Studio](https://github.com/RicoSuter/NSwag/wiki/NSwagStudio) file by including it in the project and using the **Generate with NSwag Studio** context menu
 
 
 **Custom Tools**
@@ -31,7 +31,7 @@ The output file is the result of merging all the files generated using the OpenA
 
 **Important note:**
 
-The custom tool code generators piggy back on top of well known Open API client code generators like **AutoRest**, **NSwag**, and **Swagger Codegen**. These tools require **NPM**, **AutoRest**, and the **Java SDK** to be installed on the developers machine. 
+The custom tool code generators piggy back on top of well known Open API client code generators like **AutoRest**, **NSwag**, **OpenAPI Generator**, and **Swagger Codegen**. These tools require [NPM](https://www.npmjs.com/get-npm), **AutoRest**, and the [Java SDK](https://java.com/en/download/manual.jsp) to be installed on the developers machine. 
 
 The **Swagger Codegen CLI** and **OpenAPI Generator** are downloaded on demand but requires the Java SDK to be installed on the machine. This also means that using the **SwaggerCodeGenerator** and **OpenApiCodeGenerator** custom tools have a initial delay upon first time use. The generated code that these tools produce depends on the [RestSharp v105.1.0](https://www.nuget.org/packages/RestSharp/105.1.0) and [JsonSubTypes v1.2.0](https://www.nuget.org/packages/JsonSubTypes/1.2.0) nuget packages
 

--- a/src/ApiClientCodeGen.VSIX/ApiClientCodeGen.VSIX.csproj
+++ b/src/ApiClientCodeGen.VSIX/ApiClientCodeGen.VSIX.csproj
@@ -296,6 +296,10 @@
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
+    <Reference Include="VSLangProj, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\VSLangProj.7.0.3301\lib\net10\VSLangProj.dll</HintPath>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>

--- a/src/ApiClientCodeGen.VSIX/Commands/AddNew/NewRestClientCommand.cs
+++ b/src/ApiClientCodeGen.VSIX/Commands/AddNew/NewRestClientCommand.cs
@@ -9,6 +9,7 @@ using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Windows;
 using EnvDTE;
 using Microsoft.VisualStudio.Shell;
 using Newtonsoft.Json;
+using VSLangProj;
 using Task = System.Threading.Tasks.Task;
 
 namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Commands.AddNew
@@ -55,7 +56,8 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Commands.AddNew
 
             var fileInfo = new FileInfo(filePath);
             var project = ProjectExtensions.GetActiveProject(dte);
-            var projectItem = project.AddFileToProject(dte, fileInfo);
+            var projectItem = project.AddFileToProject(dte, fileInfo, "None");
+            projectItem.Properties.Item("BuildAction").Value = prjBuildAction.prjBuildActionNone;
 
             if (CodeGenerator != SupportedCodeGenerator.NSwagStudio)
             {

--- a/src/ApiClientCodeGen.VSIX/Generators/FileHelper.cs
+++ b/src/ApiClientCodeGen.VSIX/Generators/FileHelper.cs
@@ -1,5 +1,6 @@
-﻿using System.IO;
-using EnvDTE;
+﻿using System;
+using System.IO;
+using System.Security.Cryptography;
 
 namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Generators
 {
@@ -14,6 +15,18 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Generators
             finally
             {
                 File.Delete(outputFile);
+            }
+        }
+
+        public static string CalculateMd5(string filename)
+        {
+            using (var md5 = MD5.Create())
+            {
+                using (var stream = File.OpenRead(filename))
+                {
+                    var hash = md5.ComputeHash(stream);
+                    return BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
+                }
             }
         }
     }

--- a/src/ApiClientCodeGen.VSIX/Generators/FileHelper.cs
+++ b/src/ApiClientCodeGen.VSIX/Generators/FileHelper.cs
@@ -21,13 +21,11 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Generators
         public static string CalculateMd5(string filename)
         {
             using (var md5 = MD5.Create())
-            {
-                using (var stream = File.OpenRead(filename))
-                {
-                    var hash = md5.ComputeHash(stream);
-                    return BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
-                }
-            }
+            using (var stream = File.OpenRead(filename))
+                return BitConverter
+                    .ToString(md5.ComputeHash(stream))
+                    .Replace("-", "")
+                    .ToUpperInvariant();
         }
     }
 }

--- a/src/ApiClientCodeGen.VSIX/Generators/OpenApi/OpenApiCSharpCodeGenerator.cs
+++ b/src/ApiClientCodeGen.VSIX/Generators/OpenApi/OpenApiCSharpCodeGenerator.cs
@@ -9,6 +9,8 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Generators.Open
 {
     public class OpenApiCSharpCodeGenerator : ICodeGenerator
     {
+        private const string DownloadUrl = "http://central.maven.org/maven2/org/openapitools/openapi-generator-cli/4.0.0/openapi-generator-cli-4.0.0.jar";
+        private const string Checksum = "61574C43BEC9B6EDD54E2DD0993F81D5";
         private readonly string swaggerFile;
         private readonly string defaultNamespace;
         private readonly string cliPath;
@@ -38,12 +40,12 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Generators.Open
 
                 var arguments =
                     $"-jar \"{cliPath}\" generate " +
-                    $"-l csharp " +
+                    "-g csharp " +
                     $"--input-spec \"{swaggerFile}\" " +
                     $"--output \"{output}\" " +
-                    $"-DapiTests=false -DmodelTests=false " +
+                    "-DapiTests=false -DmodelTests=false " +
                     $"-DpackageName={defaultNamespace} " +
-                    $"--skip-overwrite ";
+                    "--skip-overwrite ";
 
                 ProcessHelper.StartProcess("java", arguments);
                 pGenerateProgress.Progress(80);
@@ -58,16 +60,10 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Generators.Open
 
         private void VerifySwaggerCodegenCli()
         {
-            if (File.Exists(cliPath))
+            if (File.Exists(cliPath) && FileHelper.CalculateMd5(cliPath) == Checksum)
                 return;
 
-            const string url =
-                "http://central.maven.org/maven2/org/openapitools/openapi-generator-cli/3.3.4/openapi-generator-cli-3.3.4.jar";
-
-            new WebClient()
-                .DownloadFile(
-                    url,
-                    cliPath);
+            new WebClient().DownloadFile(DownloadUrl, cliPath);
         }
 
         private static string MergeFilesAndDeleteFolder(string output)

--- a/src/ApiClientCodeGen.VSIX/Generators/OpenApi/OpenApiCSharpCodeGenerator.cs
+++ b/src/ApiClientCodeGen.VSIX/Generators/OpenApi/OpenApiCSharpCodeGenerator.cs
@@ -40,7 +40,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Generators.Open
 
                 var arguments =
                     $"-jar \"{cliPath}\" generate " +
-                    "-g csharp " +
+                    "-g csharp-netcore " +
                     $"--input-spec \"{swaggerFile}\" " +
                     $"--output \"{output}\" " +
                     "-DapiTests=false -DmodelTests=false " +

--- a/src/ApiClientCodeGen.VSIX/packages.config
+++ b/src/ApiClientCodeGen.VSIX/packages.config
@@ -55,4 +55,5 @@
   <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
   <package id="UtilPack.NuGet.MSBuild" version="2.7.0" targetFramework="net461" developmentDependency="true" />
+  <package id="VSLangProj" version="7.0.3301" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
Changes here use the version 4.0.0 of the OpenAPI Generator tool

This also fixes #25 by setting the Build Action of the OpenAPI specification file to None when adding it via the Add - New REST API Client context menu