### PR TITLE
Do not update Newtonsoft.Json NuGet package

### DIFF
--- a/src/ApiClientCodeGen.VSIX/Commands/CustomTool/CustomToolSetter.cs
+++ b/src/ApiClientCodeGen.VSIX/Commands/CustomTool/CustomToolSetter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Threading;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.CustomTool;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Extensions;
@@ -28,10 +29,14 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Commands.Custom
 
         private async Task OnExecuteAsync(DTE dte, AsyncPackage package)
         {
+            string name = typeof(T).Name.Replace("CodeGenerator", string.Empty);
+            Trace.WriteLine($"Generating code using {name}");
+
             var item = dte.SelectedItems.Item(1).ProjectItem;
             item.Properties.Item("CustomTool").Value = typeof(T).Name;
 
             var project = ProjectExtensions.GetActiveProject(dte);
+
             await project.InstallMissingPackagesAsync(
                 package,
                 typeof(T).GetSupportedCodeGenerator());

--- a/src/ApiClientCodeGen.VSIX/Extensions/ProjectExtensions.cs
+++ b/src/ApiClientCodeGen.VSIX/Extensions/ProjectExtensions.cs
@@ -193,8 +193,11 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Extensions
                 if (installedPackages.Any(
                     c => string.Equals(c.Id, packageId, StringComparison.InvariantCultureIgnoreCase)))
                 {
-                    if (installedPackages.Any(c => c.VersionString == version.ToString(3)))
+                    if (installedPackages.Any(c => c.VersionString == version.ToString(3)) || !packageDependency.ForceUpdate)
+                    {
+                        Trace.WriteLine($"{packageDependency.Name} is already installed (version {packageDependency.Version})");
                         continue;
+                    }
                 }
 
                 Trace.WriteLine($"Installing {packageId} version {version}");

--- a/src/ApiClientCodeGen.VSIX/Extensions/ProjectExtensions.cs
+++ b/src/ApiClientCodeGen.VSIX/Extensions/ProjectExtensions.cs
@@ -195,7 +195,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Extensions
                 {
                     if (installedPackages.Any(c => c.VersionString == version.ToString(3)) || !packageDependency.ForceUpdate)
                     {
-                        Trace.WriteLine($"{packageDependency.Name} is already installed (version {packageDependency.Version})");
+                        Trace.WriteLine($"{packageDependency.Name} is already installed");
                         continue;
                     }
                 }

--- a/src/ApiClientCodeGen.VSIX/NuGet/PackageDependency.cs
+++ b/src/ApiClientCodeGen.VSIX/NuGet/PackageDependency.cs
@@ -5,14 +5,16 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.NuGet
 {
     public class PackageDependency
     {
-        public PackageDependency(string name, Version version)
+        public PackageDependency(string name, Version version, bool forceUpdate = false)
         {
             Name = name;
             Version = version;
+            ForceUpdate = forceUpdate;
         }
 
         public string Name { get; set; }
         public Version Version { get; set; }
+        public bool ForceUpdate { get; set; }
 
         public override bool Equals(object obj)
         {

--- a/src/ApiClientCodeGen.VSIX/NuGet/PackageDependency.cs
+++ b/src/ApiClientCodeGen.VSIX/NuGet/PackageDependency.cs
@@ -5,7 +5,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.NuGet
 {
     public class PackageDependency
     {
-        public PackageDependency(string name, Version version, bool forceUpdate = false)
+        public PackageDependency(string name, Version version, bool forceUpdate = true)
         {
             Name = name;
             Version = version;

--- a/src/ApiClientCodeGen.VSIX/NuGet/PackageDependencyListProvider.cs
+++ b/src/ApiClientCodeGen.VSIX/NuGet/PackageDependencyListProvider.cs
@@ -16,7 +16,8 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.NuGet
                 case SupportedCodeGenerator.NSwagStudio:
                     yield return new PackageDependency(
                         "Newtonsoft.Json",
-                        new Version(12, 0, 1, 0));
+                        new Version(12, 0, 2, 0),
+                        false);
                     break;
 
                 case SupportedCodeGenerator.AutoRest:


### PR DESCRIPTION
This resolves issue #31 where the Newtonsoft.Json nuget package was always updated (or downgraded) to version 12.0.1