### PR TITLE
Fix Missing Package References

### DIFF
--- a/src/ApiClientCodeGen.Tests/NuGet/PackageDependencyListProviderTests.cs
+++ b/src/ApiClientCodeGen.Tests/NuGet/PackageDependencyListProviderTests.cs
@@ -53,42 +53,90 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Tests.NuGet
         public void GetDependencies_NSwag_Contains_NewtonsoftJson()
             => sut.GetDependencies(SupportedCodeGenerator.NSwag)
                 .Should()
-                .Contain(c => c.Name == "Newtonsoft.Json");
+                .Contain(PackageDependencies.NewtonsoftJson);
+
+        [TestMethod]
+        public void GetDependencies_NSwag_Contains_SystemRuntimeSerializationPrimitives()
+            => sut.GetDependencies(SupportedCodeGenerator.NSwag)
+                .Should()
+                .Contain(PackageDependencies.SystemRuntimeSerializationPrimitives);
+
+        [TestMethod]
+        public void GetDependencies_NSwag_Contains_SystemComponentModelAnnotations()
+            => sut.GetDependencies(SupportedCodeGenerator.NSwag)
+                .Should()
+                .Contain(PackageDependencies.SystemComponentModelAnnotations);
 
         [TestMethod]
         public void GetDependencies_NSwagStudio_Contains_NewtonsoftJson()
             => sut.GetDependencies(SupportedCodeGenerator.NSwagStudio)
                 .Should()
-                .Contain(c => c.Name == "Newtonsoft.Json");
+                .Contain(PackageDependencies.NewtonsoftJson);
+
+        [TestMethod]
+        public void GetDependencies_NSwagStudio_Contains_SystemRuntimeSerializationPrimitives()
+            => sut.GetDependencies(SupportedCodeGenerator.NSwagStudio)
+                .Should()
+                .Contain(PackageDependencies.SystemRuntimeSerializationPrimitives);
+
+        [TestMethod]
+        public void GetDependencies_NSwagStudio_Contains_SystemComponentModelAnnotations()
+            => sut.GetDependencies(SupportedCodeGenerator.NSwagStudio)
+                .Should()
+                .Contain(PackageDependencies.SystemComponentModelAnnotations);
 
         [TestMethod]
         public void GetDependencies_AutoRest_Contains_RestClientRuntime()
             => sut.GetDependencies(SupportedCodeGenerator.AutoRest)
                 .Should()
-                .Contain(c => c.Name == "Microsoft.Rest.ClientRuntime");
+                .Contain(PackageDependencies.MicrosoftRestClientRuntime);
 
         [TestMethod]
         public void GetDependencies_Swagger_Contains_RestSharp()
             => sut.GetDependencies(SupportedCodeGenerator.Swagger)
                 .Should()
-                .Contain(c => c.Name == "RestSharp");
+                .Contain(PackageDependencies.RestSharp);
 
         [TestMethod]
         public void GetDependencies_Swagger_Contains_JsonSubTypes()
             => sut.GetDependencies(SupportedCodeGenerator.Swagger)
                 .Should()
-                .Contain(c => c.Name == "JsonSubTypes");
+                .Contain(PackageDependencies.JsonSubTypes);
+
+        [TestMethod]
+        public void GetDependencies_Swagger_Contains_SystemRuntimeSerializationPrimitives()
+            => sut.GetDependencies(SupportedCodeGenerator.NSwag)
+                .Should()
+                .Contain(PackageDependencies.SystemRuntimeSerializationPrimitives);
+
+        [TestMethod]
+        public void GetDependencies_Swagger_Contains_SystemComponentModelAnnotations()
+            => sut.GetDependencies(SupportedCodeGenerator.NSwag)
+                .Should()
+                .Contain(PackageDependencies.SystemComponentModelAnnotations);
 
         [TestMethod]
         public void GetDependencies_OpenApi_Contains_RestSharp()
             => sut.GetDependencies(SupportedCodeGenerator.OpenApi)
                 .Should()
-                .Contain(c => c.Name == "RestSharp");
+                .Contain(PackageDependencies.RestSharp);
 
         [TestMethod]
         public void GetDependencies_OpenApi_Contains_JsonSubTypes()
             => sut.GetDependencies(SupportedCodeGenerator.OpenApi)
                 .Should()
-                .Contain(c => c.Name == "JsonSubTypes");
+                .Contain(PackageDependencies.JsonSubTypes);
+
+        [TestMethod]
+        public void GetDependencies_OpenApi_Contains_SystemRuntimeSerializationPrimitives()
+            => sut.GetDependencies(SupportedCodeGenerator.OpenApi)
+                .Should()
+                .Contain(PackageDependencies.SystemRuntimeSerializationPrimitives);
+
+        [TestMethod]
+        public void GetDependencies_OpenApi_Contains_SystemComponentModelAnnotations()
+            => sut.GetDependencies(SupportedCodeGenerator.OpenApi)
+                .Should()
+                .Contain(PackageDependencies.SystemComponentModelAnnotations);
     }
 }

--- a/src/ApiClientCodeGen.VSIX/ApiClientCodeGen.VSIX.csproj
+++ b/src/ApiClientCodeGen.VSIX/ApiClientCodeGen.VSIX.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Generators\NSwagStudio\NSwagStudioFileHelper.cs" />
     <Compile Include="Extensions\SwaggerDocumentExtensions.cs" />
     <Compile Include="Generators\NSwag\NSwagCSharpCodeGenerator.cs" />
+    <Compile Include="NuGet\PackageDependencies.cs" />
     <Compile Include="Options\CustomPathOptions.cs" />
     <Compile Include="Options\IGeneralOptions.cs" />
     <Compile Include="Options\INSwagOption.cs" />

--- a/src/ApiClientCodeGen.VSIX/Extensions/ProjectExtensions.cs
+++ b/src/ApiClientCodeGen.VSIX/Extensions/ProjectExtensions.cs
@@ -15,7 +15,6 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TextManager.Interop;
 using NuGet.VisualStudio;
-using Debugger = System.Diagnostics.Debugger;
 
 namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Extensions
 {
@@ -205,17 +204,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Extensions
 
             var requiredPackages = codeGenerator.GetDependencies();
             foreach (var packageDependency in requiredPackages)
-            {
                 InstallPackageDependency(project, packageDependency, installedPackages, packageInstaller);
-            }
-
-            //if (project.IsNetStandardProject())
-            {
-                foreach (var packageDependency in GetNetStandardPackageDependencies())
-                {
-                    InstallPackageDependency(project, packageDependency, installedPackages, packageInstaller);
-                }
-            }
         }
 
         private static void InstallPackageDependency(
@@ -257,44 +246,6 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Extensions
             }
         }
 
-        private static bool IsNetStandardProject(this Project project)
-        {
-            try
-            {
-                return project?.Properties
-                           ?.Item("TargetFrameworkMoniker")
-                           ?.Value
-                           ?.ToString()
-                           ?.ToLowerInvariant()
-                           ?.Contains("netstandard") ??
-                       false;
-            }
-            catch (Exception e)
-            {
-                Trace.WriteLine(e);
-                return false;
-            }
-        }
-
-        private static IEnumerable<PackageDependency> GetNetStandardPackageDependencies()
-        {
-            yield return new PackageDependency(
-                "System.Runtime",
-                new Version(4, 3, 0));
-            
-            yield return new PackageDependency(
-                "System.Runtime.Serialization.Primitives",
-                new Version(4, 3, 0));
-
-            yield return new PackageDependency(
-                "System.ComponentModel",
-                new Version(4, 3, 0));
-
-            yield return new PackageDependency(
-                "System.ComponentModel.Annotations",
-                new Version(4, 5, 0));
-        }
-
         public static string GetTopLevelNamespace(this Project item)
         {
             try
@@ -321,7 +272,6 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Extensions
     {
         public const string ASPNET_5 = "{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}";
         public const string DOTNET_Core = "{9A19103F-16F7-4668-BE54-9A1E7A4F7556}";
-        public const string NETStandard = "{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}";
         public const string WEBSITE_PROJECT = "{E24C65DC-7377-472B-9ABA-BC803B73C61A}";
         public const string UNIVERSAL_APP = "{262852C6-CD72-467D-83FE-5EEB1973A190}";
         public const string NODE_JS = "{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}";

--- a/src/ApiClientCodeGen.VSIX/NuGet/PackageDependencies.cs
+++ b/src/ApiClientCodeGen.VSIX/NuGet/PackageDependencies.cs
@@ -1,0 +1,48 @@
+﻿using System;
+
+namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.NuGet
+{
+    public static class PackageDependencies
+    {
+        public static readonly PackageDependency NewtonsoftJson =
+            new PackageDependency(
+                "Newtonsoft.Json",
+                new Version(12, 0, 2, 0),
+                false);
+
+        public static readonly PackageDependency RestClientRuntime =
+            new PackageDependency(
+                "Microsoft.Rest.ClientRuntime",
+                new Version(2, 3, 20, 0));
+
+        public static readonly PackageDependency RestSharp =
+            new PackageDependency(
+                "RestSharp",
+                new Version(105, 1, 0, 0));
+
+        public static readonly PackageDependency JsonSubTypes =
+            new PackageDependency(
+                "JsonSubTypes",
+                new Version(1, 2, 0, 0));
+
+        public static readonly PackageDependency SystemRuntime =
+            new PackageDependency(
+                "System.Runtime",
+                new Version(4, 3, 0));
+
+        public static readonly PackageDependency SerializationPrimitives =
+            new PackageDependency(
+                "System.Runtime.Serialization.Primitives",
+                new Version(4, 3, 0));
+
+        public static readonly PackageDependency ComponentModel =
+            new PackageDependency(
+                "System.ComponentModel",
+                new Version(4, 3, 0));
+
+        public static readonly PackageDependency ComponentModelAnnotations =
+            new PackageDependency(
+                "System.ComponentModel.Annotations",
+                new Version(4, 5, 0));
+    }
+}

--- a/src/ApiClientCodeGen.VSIX/NuGet/PackageDependencies.cs
+++ b/src/ApiClientCodeGen.VSIX/NuGet/PackageDependencies.cs
@@ -10,7 +10,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.NuGet
                 new Version(12, 0, 2, 0),
                 false);
 
-        public static readonly PackageDependency RestClientRuntime =
+        public static readonly PackageDependency MicrosoftRestClientRuntime =
             new PackageDependency(
                 "Microsoft.Rest.ClientRuntime",
                 new Version(2, 3, 20, 0));
@@ -25,22 +25,12 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.NuGet
                 "JsonSubTypes",
                 new Version(1, 2, 0, 0));
 
-        public static readonly PackageDependency SystemRuntime =
-            new PackageDependency(
-                "System.Runtime",
-                new Version(4, 3, 0));
-
-        public static readonly PackageDependency SerializationPrimitives =
+        public static readonly PackageDependency SystemRuntimeSerializationPrimitives =
             new PackageDependency(
                 "System.Runtime.Serialization.Primitives",
                 new Version(4, 3, 0));
 
-        public static readonly PackageDependency ComponentModel =
-            new PackageDependency(
-                "System.ComponentModel",
-                new Version(4, 3, 0));
-
-        public static readonly PackageDependency ComponentModelAnnotations =
+        public static readonly PackageDependency SystemComponentModelAnnotations =
             new PackageDependency(
                 "System.ComponentModel.Annotations",
                 new Version(4, 5, 0));

--- a/src/ApiClientCodeGen.VSIX/NuGet/PackageDependencyListProvider.cs
+++ b/src/ApiClientCodeGen.VSIX/NuGet/PackageDependencyListProvider.cs
@@ -1,6 +1,4 @@
-﻿
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core;
 
 namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.NuGet
@@ -14,26 +12,21 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.NuGet
             {
                 case SupportedCodeGenerator.NSwag:
                 case SupportedCodeGenerator.NSwagStudio:
-                    yield return new PackageDependency(
-                        "Newtonsoft.Json",
-                        new Version(12, 0, 2, 0),
-                        false);
+                    yield return PackageDependencies.NewtonsoftJson;
+                    yield return PackageDependencies.SystemRuntimeSerializationPrimitives;
+                    yield return PackageDependencies.SystemComponentModelAnnotations;
                     break;
 
                 case SupportedCodeGenerator.AutoRest:
-                    yield return new PackageDependency(
-                        "Microsoft.Rest.ClientRuntime",
-                        new Version(2, 3, 20, 0));
+                    yield return PackageDependencies.MicrosoftRestClientRuntime;
                     break;
 
                 case SupportedCodeGenerator.Swagger:
                 case SupportedCodeGenerator.OpenApi:
-                    yield return new PackageDependency(
-                        "RestSharp",
-                        new Version(105, 1, 0, 0));
-                    yield return new PackageDependency(
-                        "JsonSubTypes",
-                        new Version(1, 2, 0, 0));
+                    yield return PackageDependencies.RestSharp;
+                    yield return PackageDependencies.JsonSubTypes;
+                    yield return PackageDependencies.SystemRuntimeSerializationPrimitives;
+                    yield return PackageDependencies.SystemComponentModelAnnotations;
                     break;
             }
         }


### PR DESCRIPTION
This resolves issue #29 and #41 

Add these NuGet packages when generating code:
- System.Runtime.Serialization.Primitives 
- System.ComponentModel.Annotations

These packages are used by NSwag, Swagger Codegen, and OpenAPI Generator