### PR TITLE
[FIX] AutoRest v2.0.4283 generated code fails to build due to missing Newtonsoft.Json reference

### DIFF
--- a/src/ApiClientCodeGen.Tests/NuGet/PackageDependencyListProviderTests.cs
+++ b/src/ApiClientCodeGen.Tests/NuGet/PackageDependencyListProviderTests.cs
@@ -92,6 +92,12 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Tests.NuGet
                 .Contain(PackageDependencies.MicrosoftRestClientRuntime);
 
         [TestMethod]
+        public void GetDependencies_AutoRest_Contains_NewtonsoftJson()
+            => sut.GetDependencies(SupportedCodeGenerator.AutoRest)
+                .Should()
+                .Contain(PackageDependencies.NewtonsoftJson);
+
+        [TestMethod]
         public void GetDependencies_Swagger_Contains_RestSharp()
             => sut.GetDependencies(SupportedCodeGenerator.Swagger)
                 .Should()

--- a/src/ApiClientCodeGen.VSIX/NuGet/PackageDependencyListProvider.cs
+++ b/src/ApiClientCodeGen.VSIX/NuGet/PackageDependencyListProvider.cs
@@ -19,6 +19,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.NuGet
 
                 case SupportedCodeGenerator.AutoRest:
                     yield return PackageDependencies.MicrosoftRestClientRuntime;
+                    yield return PackageDependencies.NewtonsoftJson;
                     break;
 
                 case SupportedCodeGenerator.Swagger:


### PR DESCRIPTION
This resolves issue #43 