### PR TITLE
Microsoft csharp nuget package

### DIFF
--- a/src/ApiClientCodeGen.Tests/NuGet/PackageDependencyListProviderTests.cs
+++ b/src/ApiClientCodeGen.Tests/NuGet/PackageDependencyListProviderTests.cs
@@ -128,6 +128,12 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Tests.NuGet
                 .Contain(PackageDependencies.SystemComponentModelAnnotations);
 
         [TestMethod]
+        public void GetDependencies_Swagger_Contains_MicrosoftCSharp()
+            => sut.GetDependencies(SupportedCodeGenerator.OpenApi)
+                .Should()
+                .Contain(PackageDependencies.MicrosoftCSharp);
+
+        [TestMethod]
         public void GetDependencies_OpenApi_Contains_RestSharp()
             => sut.GetDependencies(SupportedCodeGenerator.OpenApi)
                 .Should()
@@ -150,5 +156,11 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Tests.NuGet
             => sut.GetDependencies(SupportedCodeGenerator.OpenApi)
                 .Should()
                 .Contain(PackageDependencies.SystemComponentModelAnnotations);
+
+        [TestMethod]
+        public void GetDependencies_OpenApi_Contains_MicrosoftCSharp()
+            => sut.GetDependencies(SupportedCodeGenerator.OpenApi)
+                .Should()
+                .Contain(PackageDependencies.MicrosoftCSharp);
     }
 }

--- a/src/ApiClientCodeGen.Tests/NuGet/PackageDependencyTests.cs
+++ b/src/ApiClientCodeGen.Tests/NuGet/PackageDependencyTests.cs
@@ -12,6 +12,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Tests.NuGet
         private string name;
         private Version version;
         private bool forceUpdate;
+        private bool isSystemLibrary;
         private PackageDependency sut;
 
         [TestInitialize]
@@ -21,7 +22,8 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Tests.NuGet
             name = fixture.Create<string>();
             version = fixture.Create<Version>();
             forceUpdate = fixture.Create<bool>();
-            sut = new PackageDependency(name, version, forceUpdate);
+            isSystemLibrary = fixture.Create<bool>();
+            sut = new PackageDependency(name, version, forceUpdate, isSystemLibrary);
         }
 
         [TestMethod]
@@ -30,6 +32,12 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Tests.NuGet
                     new PackageDependency(sut.Name, sut.Version, sut.ForceUpdate))
                 .Should()
                 .BeTrue();
+
+        [TestMethod]
+        public void GetHashCode_Compares_Values()
+            => sut.GetHashCode()
+                .Should()
+                .Be(new PackageDependency(sut.Name, sut.Version, sut.ForceUpdate).GetHashCode());
 
         [TestMethod]
         public void Name_Set()
@@ -42,6 +50,10 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Tests.NuGet
         [TestMethod]
         public void ForceUpdate_Set()
             => sut.ForceUpdate.Should().Be(forceUpdate);
+
+        [TestMethod]
+        public void IsSystemLibrary_Set()
+            => sut.IsSystemLibrary.Should().Be(isSystemLibrary);
 
         [TestMethod]
         public void Name_NotBeNullOrWhiteSpace()

--- a/src/ApiClientCodeGen.VSIX/ApiClientCodeGen.VSIX.csproj
+++ b/src/ApiClientCodeGen.VSIX/ApiClientCodeGen.VSIX.csproj
@@ -75,6 +75,7 @@
     <Compile Include="CustomTool\NSwag\NSwagVisualBasicCodeGenerator.cs" />
     <Compile Include="CustomTool\OpenApi\OpenApiVisualBasicCodeGenerator.cs" />
     <Compile Include="CustomTool\Swagger\SwaggerVisualBasicCodeGenerator.cs" />
+    <Compile Include="Core\ProjectTypes.cs" />
     <Compile Include="Extensions\SupportedCodeGeneratorExtensions.cs" />
     <Compile Include="Extensions\AsyncPackageExtensions.cs" />
     <Compile Include="Commands\NSwagStudio\NSwagStudioCommand.cs" />

--- a/src/ApiClientCodeGen.VSIX/Core/ProjectTypes.cs
+++ b/src/ApiClientCodeGen.VSIX/Core/ProjectTypes.cs
@@ -1,4 +1,4 @@
-﻿namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.IntegrationTests.Build
+﻿namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core
 {
     public enum ProjectTypes
     {

--- a/src/ApiClientCodeGen.VSIX/Extensions/ProjectExtensions.cs
+++ b/src/ApiClientCodeGen.VSIX/Extensions/ProjectExtensions.cs
@@ -265,6 +265,25 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Extensions
             }
             return null;
         }
+
+        public static bool IsNetStandardLibrary(this Project project)
+        {
+            try
+            {
+                var fileName = project.FileName;
+                Trace.WriteLine("Project filename = " + fileName);
+                var contents = File.ReadAllText(fileName);
+                var result = contents.Contains("<TargetFramework>netstandard");
+                return result;
+            }
+            catch (Exception e)
+            {
+                Trace.WriteLine("Unable to read project file contents");
+                Trace.WriteLine(e);
+            }
+
+            return false;
+        }
     }
 
     public static class ProjectTypes

--- a/src/ApiClientCodeGen.VSIX/Extensions/ProjectExtensions.cs
+++ b/src/ApiClientCodeGen.VSIX/Extensions/ProjectExtensions.cs
@@ -223,6 +223,16 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Extensions
                 return;
             }
 
+            if (packageDependency.IsSystemLibrary)
+            {
+                Trace.WriteLine("Package is a system library");
+                if (!project.IsNetStandardLibrary())
+                {
+                    Trace.WriteLine("Skipping package installation");
+                    return;
+                }
+            }
+
             Trace.WriteLine($"Installing {packageId} version {version}");
 
             try

--- a/src/ApiClientCodeGen.VSIX/NuGet/PackageDependencies.cs
+++ b/src/ApiClientCodeGen.VSIX/NuGet/PackageDependencies.cs
@@ -34,5 +34,10 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.NuGet
             new PackageDependency(
                 "System.ComponentModel.Annotations",
                 new Version(4, 5, 0));
+
+        public static readonly PackageDependency MicrosoftCSharp =
+            new PackageDependency(
+                "Microsoft.CSharp",
+                new Version(4, 5, 0));
     }
 }

--- a/src/ApiClientCodeGen.VSIX/NuGet/PackageDependencies.cs
+++ b/src/ApiClientCodeGen.VSIX/NuGet/PackageDependencies.cs
@@ -28,16 +28,19 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.NuGet
         public static readonly PackageDependency SystemRuntimeSerializationPrimitives =
             new PackageDependency(
                 "System.Runtime.Serialization.Primitives",
-                new Version(4, 3, 0));
+                new Version(4, 3, 0),
+                isSystemLibrary: true);
 
         public static readonly PackageDependency SystemComponentModelAnnotations =
             new PackageDependency(
                 "System.ComponentModel.Annotations",
-                new Version(4, 5, 0));
+                new Version(4, 5, 0),
+                isSystemLibrary: true);
 
         public static readonly PackageDependency MicrosoftCSharp =
             new PackageDependency(
                 "Microsoft.CSharp",
-                new Version(4, 5, 0));
+                new Version(4, 5, 0),
+                isSystemLibrary: true);
     }
 }

--- a/src/ApiClientCodeGen.VSIX/NuGet/PackageDependency.cs
+++ b/src/ApiClientCodeGen.VSIX/NuGet/PackageDependency.cs
@@ -5,16 +5,22 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.NuGet
 {
     public sealed class PackageDependency
     {
-        public PackageDependency(string name, Version version, bool forceUpdate = true)
+        public PackageDependency(
+            string name, 
+            Version version, 
+            bool forceUpdate = true, 
+            bool isSystemLibrary = false)
         {
             Name = name;
             Version = version;
             ForceUpdate = forceUpdate;
+            IsSystemLibrary = isSystemLibrary;
         }
 
         public string Name { get; }
         public Version Version { get; }
         public bool ForceUpdate { get; }
+        public bool IsSystemLibrary { get; set; }
 
         public override bool Equals(object obj)
         {

--- a/src/ApiClientCodeGen.VSIX/NuGet/PackageDependencyListProvider.cs
+++ b/src/ApiClientCodeGen.VSIX/NuGet/PackageDependencyListProvider.cs
@@ -28,6 +28,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.NuGet
                     yield return PackageDependencies.JsonSubTypes;
                     yield return PackageDependencies.SystemRuntimeSerializationPrimitives;
                     yield return PackageDependencies.SystemComponentModelAnnotations;
+                    yield return PackageDependencies.MicrosoftCSharp;
                     break;
             }
         }

--- a/src/ApiClientCodegen.IntegrationTests/ApiClientCodegen.IntegrationTests.csproj
+++ b/src/ApiClientCodegen.IntegrationTests/ApiClientCodegen.IntegrationTests.csproj
@@ -336,7 +336,6 @@
     <Compile Include="Build\Projects\AutoRestProjectFileContents.cs" />
     <Compile Include="Build\BuildHelper.cs" />
     <Compile Include="Build\Projects\NSwagProjectFileContents.cs" />
-    <Compile Include="Build\ProjectTypes.cs" />
     <Compile Include="Build\Projects\SwaggerProjectFileContents.cs" />
     <Compile Include="Converters\CSharpToVisualBasicLanguageConverterTests.cs" />
     <Compile Include="CustomTool\CSharpSingleFileCodeGeneratorTests.cs" />

--- a/src/ApiClientCodegen.IntegrationTests/Build/Projects/SwaggerProjectFileContents.cs
+++ b/src/ApiClientCodegen.IntegrationTests/Build/Projects/SwaggerProjectFileContents.cs
@@ -25,7 +25,6 @@
     <PackageReference Include = ""RestSharp"" Version=""105.1.0"" />
     <PackageReference Include = ""System.ComponentModel.Annotations"" Version=""4.5.0"" />
     <PackageReference Include = ""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
-    <PackageReference Include = ""Microsoft.CSharp"" Version=""4.5.0"" />
   </ItemGroup>
 </Project>";
     }

--- a/src/ApiClientCodegen.IntegrationTests/Build/Projects/SwaggerProjectFileContents.cs
+++ b/src/ApiClientCodegen.IntegrationTests/Build/Projects/SwaggerProjectFileContents.cs
@@ -25,6 +25,7 @@
     <PackageReference Include = ""RestSharp"" Version=""105.1.0"" />
     <PackageReference Include = ""System.ComponentModel.Annotations"" Version=""4.5.0"" />
     <PackageReference Include = ""System.Runtime.Serialization.Primitives"" Version=""4.3.0"" />
+    <PackageReference Include = ""Microsoft.CSharp"" Version=""4.5.0"" />
   </ItemGroup>
 </Project>";
     }


### PR DESCRIPTION
This resolves #49

There aren't MIcrosoft provided API's (or at least I couldn't find them) for checking the Project type so I had to introduce a poor man way of checking if a project is a .NET Standard project by simply checking if the "netstandard" text is present in the Project file