### PR TITLE
Fix Visual Studio for Mac Extension builds

### DIFF
--- a/.github/workflows/vsmac.yml
+++ b/.github/workflows/vsmac.yml
@@ -29,8 +29,8 @@ jobs:
       working-directory: src
 
     - name: Archive binaries
-      run: zip VSMac-Binaries.zip ./ApiClientCodeGen.VSMac/bin/Release/net48/*
-      working-directory: src
+      run: zip -r VSMac-Binaries.zip .
+      working-directory: src/ApiClientCodeGen.VSMac/bin/Release/net48/
 
     - name: Publish binaries
       uses: actions/upload-artifact@v2

--- a/.github/workflows/vsmac.yml
+++ b/.github/workflows/vsmac.yml
@@ -36,7 +36,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: Binaries
-        path: src/VSMac-Binaries.zip
+        path: src/ApiClientCodeGen.VSMac/bin/Release/net48/VSMac-Binaries.zip
 
     - name: Create mpack file
       run: make package

--- a/.github/workflows/vsmac.yml
+++ b/.github/workflows/vsmac.yml
@@ -39,8 +39,8 @@ jobs:
         path: src/ApiClientCodeGen.VSMac/bin/Release/net48/VSMac-Binaries.zip
 
     - name: Create mpack file
-      run: make package
-      working-directory: src
+      run: /Applications/Visual\ Studio.app/Contents/MacOS/vstool setup pack ApiClientCodeGen.VSMac.dll -d:"../../../../../src"
+      working-directory: src/ApiClientCodeGen.VSMac/bin/Release/net48/
 
     - name: Rename build output
       run: mv *.mpack ApiClientCodeGenerator-1.0.${{ github.run_number }}.mpack

--- a/.github/workflows/vsmac.yml
+++ b/.github/workflows/vsmac.yml
@@ -25,7 +25,7 @@ jobs:
       working-directory: src/ApiClientCodeGen.VSMac/Properties
 
     - name: Build
-      run: make package
+      run: make release
       working-directory: src
 
     - name: Archive binaries
@@ -39,8 +39,8 @@ jobs:
         path: src/ApiClientCodeGen.VSMac/bin/Release/net48/VSMac-Binaries.zip
 
     - name: Create mpack file
-      run: /Applications/Visual\ Studio.app/Contents/MacOS/vstool setup pack ApiClientCodeGen.VSMac.dll -d:"../../../../../src"
-      working-directory: src/ApiClientCodeGen.VSMac/bin/Release/net48/
+      run: make package
+      working-directory: src
 
     - name: Rename build output
       run: mv *.mpack ApiClientCodeGenerator-1.0.${{ github.run_number }}.mpack

--- a/.github/workflows/vsmac.yml
+++ b/.github/workflows/vsmac.yml
@@ -19,7 +19,9 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Update Extension Version Info
-      run: sed -i -e 's/1.0/1.0.${{ github.run_number }}/g' ./AddinInfo.cs
+      run: |
+        sed -i -e 's/1.0/1.0.${{ github.run_number }}/g' ./AddinInfo.cs
+        cat ./AddinInfo.cs
       working-directory: src/ApiClientCodeGen.VSMac/Properties
 
     - name: Build

--- a/.github/workflows/vsmac.yml
+++ b/.github/workflows/vsmac.yml
@@ -28,6 +28,16 @@ jobs:
       run: make package
       working-directory: src
 
+    - name: Archive binaries
+      run: zip VSMac-Binaries.zip ./ApiClientCodeGen.VSMac/bin/Release/net48/*
+      working-directory: src
+
+    - name: Publish artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: Artifacts
+        path: VSMac-Binaries.zip
+
     - name: Create mpack file
       run: make package
       working-directory: src

--- a/.github/workflows/vsmac.yml
+++ b/.github/workflows/vsmac.yml
@@ -32,11 +32,11 @@ jobs:
       run: zip VSMac-Binaries.zip ./ApiClientCodeGen.VSMac/bin/Release/net48/*
       working-directory: src
 
-    - name: Publish artifacts
+    - name: Publish binaries
       uses: actions/upload-artifact@v2
       with:
         name: Artifacts
-        path: VSMac-Binaries.zip
+        path: src/VSMac-Binaries.zip
 
     - name: Create mpack file
       run: make package

--- a/.github/workflows/vsmac.yml
+++ b/.github/workflows/vsmac.yml
@@ -26,6 +26,10 @@ jobs:
       run: make package
       working-directory: src
 
+    - name: Create mpack file
+      run: make package
+      working-directory: src
+
     - name: Rename build output
       run: mv *.mpack ApiClientCodeGenerator-1.0.${{ github.run_number }}.mpack
       working-directory: src

--- a/.github/workflows/vsmac.yml
+++ b/.github/workflows/vsmac.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
 
-    runs-on: macos-latest
+    runs-on: macos-11.0
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/vsmac.yml
+++ b/.github/workflows/vsmac.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Publish binaries
       uses: actions/upload-artifact@v2
       with:
-        name: Artifacts
+        name: Binaries
         path: src/VSMac-Binaries.zip
 
     - name: Create mpack file
@@ -53,7 +53,7 @@ jobs:
     - name: Publish artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: Artifacts
+        name: Extension
         path: |
           src/*.mpack
           src/*.mrep

--- a/build/templates/vsmac.yml
+++ b/build/templates/vsmac.yml
@@ -10,10 +10,25 @@ jobs:
   - bash: |
       cd $(system.defaultworkingdirectory)/src
       sed -i -e 's/1.0/$(build.buildnumber)/g' ApiClientCodeGen.VSMac/Properties/AddinInfo.cs
+      cat ApiClientCodeGen.VSMac/Properties/AddinInfo.cs
+    displayName: 'Update version information'
+  
+  - bash: |
+      cd $(system.defaultworkingdirectory)/src
+      make release
+    displayName: 'Build'
+  
+  - bash: |
+      cd $(system.defaultworkingdirectory)/src
       make package
       mv ApiClientCodeGen.VSMac.ApiClientCodeGenerator_$(build.buildnumber).mpack ApiClientCodeGenerator-$(build.buildnumber).mpack
       make publish
-    displayName: 'Build .mpack file'
+    displayName: 'Create .mpack file'
+  
+  - bash: |
+      cd $(system.defaultworkingdirectory)/src/ApiClientCodeGen.VSMac/bin/Release/net48/
+      zip -r VSMac-Binaries.zip .
+    displayName: 'Archive Binaries'
 
   - task: CopyFiles@2
     displayName: 'Copy Files to: $(build.artifactstagingdirectory)'
@@ -23,6 +38,7 @@ jobs:
         *.mpack
         *.mrep
         index.html
+        **/VSMac-Binaries.zip
       targetFolder: '$(build.artifactstagingdirectory)'
       flattenFolders: true
 

--- a/src/ApiClientCodeGen.VSMac/ApiClientCodeGen.VSMac.csproj
+++ b/src/ApiClientCodeGen.VSMac/ApiClientCodeGen.VSMac.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/src/ApiClientCodeGen.VSMac/ApiClientCodeGen.VSMac.csproj
+++ b/src/ApiClientCodeGen.VSMac/ApiClientCodeGen.VSMac.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net471</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Makefile
+++ b/src/Makefile
@@ -12,7 +12,7 @@ release: restore-packages
 	msbuild /p:Configuration="Release" /t:"Rebuild" Mac.sln
 
 package:
-	/Applications/Visual\ Studio.app/Contents/MacOS/vstool setup pack ./ApiClientCodeGen.VSMac/bin/Release/net471/ApiClientCodeGen.VSMac.dll
+	/Applications/Visual\ Studio.app/Contents/MacOS/vstool setup pack ./ApiClientCodeGen.VSMac/bin/Release/net472/ApiClientCodeGen.VSMac.dll
 
 publish:
 	/Applications/Visual\ Studio.app/Contents/MacOS/vstool setup rep-build .

--- a/src/Makefile
+++ b/src/Makefile
@@ -9,10 +9,9 @@ debug: restore-packages
 	msbuild /p:Configuration="Debug" /t:"Rebuild" Mac.sln
 
 release: restore-packages
-	msbuild /p:Configuration="Release" /t:"Rebuild" Mac.sln
+	/Applications/Visual\ Studio.app/Contents/MacOS/vstool build --configuration:Release Mac.sln
 
 package:
-	/Applications/Visual\ Studio.app/Contents/MacOS/vstool setup help pack
 	/Applications/Visual\ Studio.app/Contents/MacOS/vstool setup pack ./ApiClientCodeGen.VSMac/bin/Release/net48/ApiClientCodeGen.VSMac.dll
 
 publish:

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,7 @@
 all: debug release package publish
 	
 restore-packages: 
-	nuget restore Mac.sln
+	msbuild /t:"Restore" Mac.sln
 
 debug: restore-packages
 	msbuild /p:Configuration="Debug" /t:"Rebuild" Mac.sln

--- a/src/Makefile
+++ b/src/Makefile
@@ -12,7 +12,7 @@ release: restore-packages
 	msbuild /p:Configuration="Release" /t:"Rebuild" Mac.sln
 
 package: release
-	/Applications/Visual\ Studio.app/Contents/MacOS/vstool setup pack ./ApiClientCodeGen.VSMac/bin/Release/net471/ApiClientCodeGen.VSMac.dll -format:mpack -debugSymbols:true
+	/Applications/Visual\ Studio.app/Contents/MacOS/vstool setup pack ./ApiClientCodeGen.VSMac/bin/Release/net471/ApiClientCodeGen.VSMac.dll
 
 publish:
 	/Applications/Visual\ Studio.app/Contents/MacOS/vstool setup rep-build .

--- a/src/Makefile
+++ b/src/Makefile
@@ -12,6 +12,7 @@ release: restore-packages
 	msbuild /p:Configuration="Release" /t:"Rebuild" Mac.sln
 
 package:
+	/Applications/Visual\ Studio.app/Contents/MacOS/vstool setup help pack
 	/Applications/Visual\ Studio.app/Contents/MacOS/vstool setup pack ./ApiClientCodeGen.VSMac/bin/Release/net48/ApiClientCodeGen.VSMac.dll
 
 publish:

--- a/src/Makefile
+++ b/src/Makefile
@@ -12,7 +12,7 @@ release: restore-packages
 	msbuild /p:Configuration="Release" /t:"Rebuild" Mac.sln
 
 package:
-	/Applications/Visual\ Studio.app/Contents/MacOS/vstool setup pack ./ApiClientCodeGen.VSMac/bin/Release/net472/ApiClientCodeGen.VSMac.dll
+	/Applications/Visual\ Studio.app/Contents/MacOS/vstool setup pack ./ApiClientCodeGen.VSMac/bin/Release/net48/ApiClientCodeGen.VSMac.dll
 
 publish:
 	/Applications/Visual\ Studio.app/Contents/MacOS/vstool setup rep-build .

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,6 @@
 .PHONY: restore-packages debug release
 
-all: debug release
+all: debug release package publish
 	
 restore-packages: 
 	nuget restore Mac.sln
@@ -11,7 +11,7 @@ debug: restore-packages
 release: restore-packages
 	msbuild /p:Configuration="Release" /t:"Rebuild" Mac.sln
 
-package: release
+package:
 	/Applications/Visual\ Studio.app/Contents/MacOS/vstool setup pack ./ApiClientCodeGen.VSMac/bin/Release/net471/ApiClientCodeGen.VSMac.dll
 
 publish:


### PR DESCRIPTION
All of the sudden using `msbuild` to build the Visual Studio for Mac on the hosted MacOS agents. 

```
/Applications/Visual\ Studio.app/Contents/MacOS/vstool setup pack ./ApiClientCodeGen.VSMac/bin/Release/net471/ApiClientCodeGen.VSMac.dll -format:mpack -debugSymbols:true
INFO [2020-10-31 12:25:14Z]: Did not find previous version from which to migrate data
Visual Studio Extension Setup Utility
ERROR: Could not read add-in file: ./ApiClientCodeGen.VSMac/bin/Release/net471/ApiClientCodeGen.VSMac.dll
```

Switching to using `vstool build` to build the solution seems to have solved the issue

This resolves #95 