### PR TITLE
Fix Missing AutoRest v3 package references when using "Add New REST API Client" command

### DIFF
--- a/src/VSIX/ApiClientCodeGen.VSIX/Commands/AddNew/NewAutoRestClientCommand.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX/Commands/AddNew/NewAutoRestClientCommand.cs
@@ -1,5 +1,13 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators.AutoRest;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators.NSwagStudio;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Extensions;
+using EnvDTE;
+using Microsoft.VisualStudio.Shell;
+using NSwag;
+using Task = System.Threading.Tasks.Task;
 
 namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Commands.AddNew
 {
@@ -9,5 +17,35 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Commands.AddNew
         protected override int CommandId { get; } = 0x0200;
 
         protected override SupportedCodeGenerator CodeGenerator { get; } = SupportedCodeGenerator.AutoRest;
+
+        protected override async Task OnInstallPackagesAsync(
+            AsyncPackage package,
+            Project project,
+            EnterOpenApiSpecDialogResult dialogResult)
+        {
+            var url = dialogResult.Url;
+            const StringComparison comparisonType = StringComparison.OrdinalIgnoreCase;
+            var document = url.EndsWith("yaml", comparisonType) || url.EndsWith("yml", comparisonType)
+                ? await OpenApiYamlDocument.FromYamlAsync(dialogResult.OpenApiSpecification)
+                : await OpenApiDocument.FromJsonAsync(dialogResult.OpenApiSpecification);
+
+            var codeGenerator = GetSupportedCodeGenerator(document);
+            await project.InstallMissingPackagesAsync(package, codeGenerator);
+
+            if (codeGenerator == SupportedCodeGenerator.AutoRestV3)
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                project.Save();
+
+                await project.UpdatePropertyGroups(AutoRestConstants.PropertyGroups);
+            }
+        }
+
+        private static SupportedCodeGenerator GetSupportedCodeGenerator(OpenApiDocument document)
+            => !string.IsNullOrEmpty(document.OpenApi) &&
+               Version.TryParse(document.OpenApi, out var openApiVersion) &&
+               openApiVersion > Version.Parse("3.0.0")
+                ? SupportedCodeGenerator.AutoRestV3
+                : SupportedCodeGenerator.AutoRest;
     }
 }

--- a/src/VSIX/ApiClientCodeGen.VSIX/Commands/AddNew/NewRestClientCommand.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX/Commands/AddNew/NewRestClientCommand.cs
@@ -84,6 +84,14 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Commands.AddNew
                 project.AddFileToProject(dte, new FileInfo(Path.Combine(folder, nswagOutput)));
             }
 
+            await OnInstallPackagesAsync(package, project, result);
+        }
+
+        protected virtual async Task OnInstallPackagesAsync(
+            AsyncPackage package,
+            Project project,
+            EnterOpenApiSpecDialogResult dialogResult)
+        {
             await project.InstallMissingPackagesAsync(package, CodeGenerator);
         }
 

--- a/src/VSIX/ApiClientCodeGen.VSIX/Extensions/ProjectExtensions.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX/Extensions/ProjectExtensions.cs
@@ -122,7 +122,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Extensions
             return false;
         }
 
-        public static Project GetActiveProject(DTE Dte)
+        public static Project GetActiveProject(this DTE Dte)
         {
             try
             {


### PR DESCRIPTION
This resolves #176 