### PR TITLE
Create options page for OpenAPI Generator settings

### DIFF
--- a/src/CLI/ApiClientCodeGen.CLI/Program.cs
+++ b/src/CLI/ApiClientCodeGen.CLI/Program.cs
@@ -11,6 +11,7 @@ using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Logging;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.AutoRest;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.General;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.NSwag;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.OpenApiGenerator;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -58,6 +59,7 @@ namespace ApiClientCodeGen.CLI
             services.AddSingleton<INSwagOptions, DefaultNSwagOptions>();
             services.AddSingleton<IGeneralOptions, DefaultGeneralOptions>();
             services.AddSingleton<IAutoRestOptions, DefaultAutoRestOptions>();
+            services.AddSingleton<IOpenApiGeneratorOptions, DefaultOpenApiGeneratorOptions>();
             services.AddSingleton<IProgressReporter, ProgressReporter>();
             services.AddSingleton<IOpenApiDocumentFactory, OpenApiDocumentFactory>();
             services.AddSingleton<INSwagCodeGeneratorSettingsFactory, NSwagCodeGeneratorSettingsFactory>();

--- a/src/Core/ApiClientCodeGen.Core.Tests/Command/OpenApiGeneratorFactoryTests.cs
+++ b/src/Core/ApiClientCodeGen.Core.Tests/Command/OpenApiGeneratorFactoryTests.cs
@@ -3,6 +3,7 @@ using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Commands;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.General;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.OpenApiGenerator;
 using FluentAssertions;
 using Xunit;
 
@@ -16,12 +17,14 @@ namespace ApiClientCodeGen.Core.Tests.Command
             string swaggerFile,
             string defaultNamespace,
             IGeneralOptions options,
+            IOpenApiGeneratorOptions openApiGeneratorOptions,
             IProcessLauncher processLauncher,
             IDependencyInstaller dependencyInstaller)
             => sut.Create(
                     swaggerFile,
                     defaultNamespace,
                     options,
+                    openApiGeneratorOptions,
                     processLauncher,
                     dependencyInstaller)
                 .Should()

--- a/src/Core/ApiClientCodeGen.Core.Tests/Generators/OpenApi/OpenApiCSharpCodeGeneratorExceptionTests.cs
+++ b/src/Core/ApiClientCodeGen.Core.Tests/Generators/OpenApi/OpenApiCSharpCodeGeneratorExceptionTests.cs
@@ -3,6 +3,7 @@ using ApiClientCodeGen.Tests.Common.Infrastructure;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators.OpenApi;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.OpenApiGenerator;
 using FluentAssertions;
 using Xunit;
 
@@ -11,60 +12,78 @@ namespace ApiClientCodeGen.Core.Tests.Generators.OpenApi
     public class OpenApiCSharpCodeGeneratorExceptionTests
     {
         [Theory, AutoMoqData]
-        public void Constructor_Requires_SwaggerFile(IProcessLauncher launcher, IDependencyInstaller installer)
+        public void Constructor_Requires_SwaggerFile(
+            IProcessLauncher launcher,
+            IDependencyInstaller installer,
+            IOpenApiGeneratorOptions openApiGeneratorOptions)
             => new Action(
                     () => new OpenApiCSharpCodeGenerator(
                         null,
                         null,
                         null,
+                        openApiGeneratorOptions,
                         launcher,
                         installer))
                 .Should()
                 .ThrowExactly<ArgumentNullException>();
 
         [Theory, AutoMoqData]
-        public void Constructor_Requires_DefaultNamespace(IProcessLauncher launcher, IDependencyInstaller installer)
+        public void Constructor_Requires_DefaultNamespace(
+            IProcessLauncher launcher,
+            IDependencyInstaller installer,
+            IOpenApiGeneratorOptions openApiGeneratorOptions)
             => new Action(
                     () => new OpenApiCSharpCodeGenerator(
                         "",
                         null,
                         null,
+                        openApiGeneratorOptions,
                         launcher,
                         installer))
                 .Should()
                 .ThrowExactly<ArgumentNullException>();
 
         [Theory, AutoMoqData]
-        public void Constructor_Requires_Options(IProcessLauncher launcher, IDependencyInstaller installer)
+        public void Constructor_Requires_Options(
+            IProcessLauncher launcher,
+            IDependencyInstaller installer,
+            IOpenApiGeneratorOptions openApiGeneratorOptions)
             => new Action(
                     () => new OpenApiCSharpCodeGenerator(
                         "",
                         "",
                         null,
+                        openApiGeneratorOptions,
                         launcher,
                         installer))
                 .Should()
                 .ThrowExactly<ArgumentNullException>();
 
         [Theory, AutoMoqData]
-        public void Constructor_Requires_ProcessLauncher(IDependencyInstaller installer)
+        public void Constructor_Requires_ProcessLauncher(
+            IDependencyInstaller installer,
+            IOpenApiGeneratorOptions openApiGeneratorOptions)
             => new Action(
                     () => new OpenApiCSharpCodeGenerator(
                         "",
                         "",
                         null,
+                        openApiGeneratorOptions,
                         null,
                         installer))
                 .Should()
                 .ThrowExactly<ArgumentNullException>();
 
         [Theory, AutoMoqData]
-        public void Constructor_Requires_DependencyInstaller(IProcessLauncher launcher)
+        public void Constructor_Requires_DependencyInstaller(
+            IProcessLauncher launcher,
+            IOpenApiGeneratorOptions openApiGeneratorOptions)
             => new Action(
                     () => new OpenApiCSharpCodeGenerator(
                         "",
                         "",
                         null,
+                        openApiGeneratorOptions,
                         launcher,
                         null))
                 .Should()

--- a/src/Core/ApiClientCodeGen.Core/Commands/OpenApiGeneratorCommand.cs
+++ b/src/Core/ApiClientCodeGen.Core/Commands/OpenApiGeneratorCommand.cs
@@ -33,6 +33,20 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Commands
             this.dependencyInstaller = dependencyInstaller ?? throw new ArgumentNullException(nameof(dependencyInstaller));
         }
 
+        [Option(
+            
+            LongName = "emit-default-value",
+            Description =
+                "Set to true if the default value for a member should be generated in the serialization stream. " +
+                "Setting the EmitDefaultValue property to false is not a recommended practice. " +
+                "It should only be done if there is a specific need to do so " +
+                "(such as for interoperability or to reduce data size).")]
+        public bool EmitDefaultValue
+        {
+            get => openApiGeneratorOptions.EmitDefaultValue;
+            set => openApiGeneratorOptions.EmitDefaultValue = value;
+        }
+
         public override ICodeGenerator CreateGenerator()
             => generatorFactory.Create(
                 SwaggerFile,

--- a/src/Core/ApiClientCodeGen.Core/Commands/OpenApiGeneratorCommand.cs
+++ b/src/Core/ApiClientCodeGen.Core/Commands/OpenApiGeneratorCommand.cs
@@ -3,6 +3,7 @@ using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Logging;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.General;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.OpenApiGenerator;
 using McMaster.Extensions.CommandLineUtils;
 
 namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Commands
@@ -11,6 +12,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Commands
     public class OpenApiGeneratorCommand : CodeGeneratorCommand
     {
         private readonly IGeneralOptions options;
+        private readonly IOpenApiGeneratorOptions openApiGeneratorOptions;
         private readonly IProcessLauncher processLauncher;
         private readonly IOpenApiGeneratorFactory generatorFactory;
         private readonly IDependencyInstaller dependencyInstaller;
@@ -19,11 +21,13 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Commands
             IConsoleOutput console,
             IProgressReporter progressReporter,
             IGeneralOptions options,
+            IOpenApiGeneratorOptions openApiGeneratorOptions,
             IProcessLauncher processLauncher,
             IOpenApiGeneratorFactory generatorFactory,
             IDependencyInstaller dependencyInstaller) : base(console, progressReporter)
         {
             this.options = options ?? throw new ArgumentNullException(nameof(options));
+            this.openApiGeneratorOptions = openApiGeneratorOptions;
             this.processLauncher = processLauncher ?? throw new ArgumentNullException(nameof(processLauncher));
             this.generatorFactory = generatorFactory ?? throw new ArgumentNullException(nameof(generatorFactory));
             this.dependencyInstaller = dependencyInstaller ?? throw new ArgumentNullException(nameof(dependencyInstaller));
@@ -34,6 +38,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Commands
                 SwaggerFile,
                 DefaultNamespace,
                 options,
+                openApiGeneratorOptions,
                 processLauncher,
                 dependencyInstaller);
     }

--- a/src/Core/ApiClientCodeGen.Core/Commands/OpenApiGeneratorFactory.cs
+++ b/src/Core/ApiClientCodeGen.Core/Commands/OpenApiGeneratorFactory.cs
@@ -2,6 +2,7 @@ using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators.OpenApi;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.General;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.OpenApiGenerator;
 
 namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Commands
 {
@@ -11,6 +12,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Commands
             string swaggerFile,
             string defaultNamespace,
             IGeneralOptions options,
+            IOpenApiGeneratorOptions openApiGeneratorOptions,
             IProcessLauncher processLauncher,
             IDependencyInstaller dependencyInstaller);
     }
@@ -21,12 +23,14 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Commands
             string swaggerFile,
             string defaultNamespace,
             IGeneralOptions options,
+            IOpenApiGeneratorOptions openApiGeneratorOptions,
             IProcessLauncher processLauncher,
             IDependencyInstaller dependencyInstaller)
             => new OpenApiCSharpCodeGenerator(
                 swaggerFile,
                 defaultNamespace,
                 options,
+                openApiGeneratorOptions,
                 processLauncher,
                 dependencyInstaller);
     }

--- a/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiCSharpCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiCSharpCodeGenerator.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.General;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.OpenApiGenerator;
 
 namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators.OpenApi
 {
@@ -19,6 +20,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
             string swaggerFile,
             string defaultNamespace,
             IGeneralOptions options,
+            IOpenApiGeneratorOptions openApiGeneratorOptions,
             IProcessLauncher processLauncher,
             IDependencyInstaller dependencyInstaller)
         {

--- a/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiCSharpCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiCSharpCodeGenerator.cs
@@ -20,20 +20,20 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
         public OpenApiCSharpCodeGenerator(
             string swaggerFile,
             string defaultNamespace,
-            IGeneralOptions options,
+            IGeneralOptions generatlOptions,
             IOpenApiGeneratorOptions openApiGeneratorOptions,
             IProcessLauncher processLauncher,
             IDependencyInstaller dependencyInstaller)
         {
             this.swaggerFile = swaggerFile ?? throw new ArgumentNullException(nameof(swaggerFile));
             this.defaultNamespace = defaultNamespace ?? throw new ArgumentNullException(nameof(defaultNamespace));
-            this.options = options ?? throw new ArgumentNullException(nameof(options));
+            this.options = generatlOptions ?? throw new ArgumentNullException(nameof(generatlOptions));
             this.openApiGeneratorOptions = openApiGeneratorOptions ??
                                            throw new ArgumentNullException(nameof(openApiGeneratorOptions));
             this.processLauncher = processLauncher ?? throw new ArgumentNullException(nameof(processLauncher));
             this.dependencyInstaller =
                 dependencyInstaller ?? throw new ArgumentNullException(nameof(dependencyInstaller));
-            javaPathProvider = new JavaPathProvider(options, processLauncher);
+            javaPathProvider = new JavaPathProvider(generatlOptions, processLauncher);
         }
 
         public string GenerateCode(IProgressReporter pGenerateProgress)

--- a/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiCSharpCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiCSharpCodeGenerator.cs
@@ -12,6 +12,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
         private readonly string defaultNamespace;
         private readonly JavaPathProvider javaPathProvider;
         private readonly IGeneralOptions options;
+        private readonly IOpenApiGeneratorOptions openApiGeneratorOptions;
         private readonly IProcessLauncher processLauncher;
         private readonly IDependencyInstaller dependencyInstaller;
         private readonly string swaggerFile;
@@ -27,8 +28,11 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
             this.swaggerFile = swaggerFile ?? throw new ArgumentNullException(nameof(swaggerFile));
             this.defaultNamespace = defaultNamespace ?? throw new ArgumentNullException(nameof(defaultNamespace));
             this.options = options ?? throw new ArgumentNullException(nameof(options));
+            this.openApiGeneratorOptions = openApiGeneratorOptions ??
+                                           throw new ArgumentNullException(nameof(openApiGeneratorOptions));
             this.processLauncher = processLauncher ?? throw new ArgumentNullException(nameof(processLauncher));
-            this.dependencyInstaller = dependencyInstaller ?? throw new ArgumentNullException(nameof(dependencyInstaller));
+            this.dependencyInstaller =
+                dependencyInstaller ?? throw new ArgumentNullException(nameof(dependencyInstaller));
             javaPathProvider = new JavaPathProvider(options, processLauncher);
         }
 
@@ -63,9 +67,13 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
                     $"--package-name \"{defaultNamespace}\" " +
                     "--global-property apiTests=false,modelTests=false " +
                     "--skip-overwrite " +
-                    "--additional-properties optionalEmitDefaultValues=true ";
+                    $"--additional-properties optionalEmitDefaultValues={openApiGeneratorOptions.EmitDefaultValue} ";
 
-                processLauncher.Start(javaPathProvider.GetJavaExePath(), arguments, Path.GetDirectoryName(swaggerFile));
+                processLauncher.Start(
+                    javaPathProvider.GetJavaExePath(),
+                    arguments,
+                    Path.GetDirectoryName(swaggerFile));
+
                 pGenerateProgress.Progress(80);
 
                 return CSharpFileMerger.MergeFilesAndDeleteSource(output);

--- a/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiCSharpCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiCSharpCodeGenerator.cs
@@ -60,7 +60,8 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
                     $"--output \"{output}\" " +
                     $"--package-name \"{defaultNamespace}\" " +
                     "--global-property apiTests=false,modelTests=false " +
-                    "--skip-overwrite ";
+                    "--skip-overwrite " +
+                    "--additional-properties optionalEmitDefaultValues=true ";
 
                 processLauncher.Start(javaPathProvider.GetJavaExePath(), arguments, Path.GetDirectoryName(swaggerFile));
                 pGenerateProgress.Progress(80);

--- a/src/Core/ApiClientCodeGen.Core/Options/OpenApiGenerator/DefaultOpenApiGeneratorOptions.cs
+++ b/src/Core/ApiClientCodeGen.Core/Options/OpenApiGenerator/DefaultOpenApiGeneratorOptions.cs
@@ -1,0 +1,7 @@
+namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.OpenApiGenerator
+{
+    public class DefaultOpenApiGeneratorOptions : IOpenApiGeneratorOptions
+    {
+        public bool EmitDefaultValue { get; } = true;
+    }
+}

--- a/src/Core/ApiClientCodeGen.Core/Options/OpenApiGenerator/DefaultOpenApiGeneratorOptions.cs
+++ b/src/Core/ApiClientCodeGen.Core/Options/OpenApiGenerator/DefaultOpenApiGeneratorOptions.cs
@@ -2,6 +2,6 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.Op
 {
     public class DefaultOpenApiGeneratorOptions : IOpenApiGeneratorOptions
     {
-        public bool EmitDefaultValue { get; } = true;
+        public bool EmitDefaultValue { get; set; } = true;
     }
 }

--- a/src/Core/ApiClientCodeGen.Core/Options/OpenApiGenerator/IOpenApiGeneratorOptions.cs
+++ b/src/Core/ApiClientCodeGen.Core/Options/OpenApiGenerator/IOpenApiGeneratorOptions.cs
@@ -1,0 +1,7 @@
+﻿namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.OpenApiGenerator
+{
+    public interface IOpenApiGeneratorOptions
+    {
+        bool EmitDefaultValue  { get; }
+    }
+}

--- a/src/Core/ApiClientCodeGen.Core/Options/OpenApiGenerator/IOpenApiGeneratorOptions.cs
+++ b/src/Core/ApiClientCodeGen.Core/Options/OpenApiGenerator/IOpenApiGeneratorOptions.cs
@@ -2,6 +2,6 @@
 {
     public interface IOpenApiGeneratorOptions
     {
-        bool EmitDefaultValue  { get; }
+        bool EmitDefaultValue  { get; set; }
     }
 }

--- a/src/Core/ApiClientCodeGen.Tests.Common/Fixtures/OpenApi3/OpenApiCodeGeneratorFixture.cs
+++ b/src/Core/ApiClientCodeGen.Tests.Common/Fixtures/OpenApi3/OpenApiCodeGeneratorFixture.cs
@@ -4,6 +4,7 @@ using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators.OpenApi;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.General;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.OpenApiGenerator;
 using Moq;
 
 namespace ApiClientCodeGen.Tests.Common.Fixtures.OpenApi3
@@ -24,6 +25,7 @@ namespace ApiClientCodeGen.Tests.Common.Fixtures.OpenApi3
                 Path.GetFullPath(SwaggerV3JsonFilename),
                 "GeneratedCode",
                 OptionsMock.Object,
+                new DefaultOpenApiGeneratorOptions(),
                 new ProcessLauncher(),
                 new DependencyInstaller(
                     new NpmInstaller(new ProcessLauncher()),

--- a/src/Core/ApiClientCodeGen.Tests.Common/Fixtures/OpenApi3/Yaml/OpenApiCodeGeneratorFixture.cs
+++ b/src/Core/ApiClientCodeGen.Tests.Common/Fixtures/OpenApi3/Yaml/OpenApiCodeGeneratorFixture.cs
@@ -4,6 +4,7 @@ using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators.OpenApi;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.General;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.OpenApiGenerator;
 using Moq;
 
 namespace ApiClientCodeGen.Tests.Common.Fixtures.OpenApi3.Yaml
@@ -24,6 +25,7 @@ namespace ApiClientCodeGen.Tests.Common.Fixtures.OpenApi3.Yaml
                 Path.GetFullPath(SwaggerV3YamlFilename),
                 "GeneratedCode",
                 OptionsMock.Object,
+                new DefaultOpenApiGeneratorOptions(),
                 new ProcessLauncher(),
                 new DependencyInstaller(
                     new NpmInstaller(new ProcessLauncher()),

--- a/src/Core/ApiClientCodeGen.Tests.Common/Fixtures/OpenApiCodeGeneratorFixture.cs
+++ b/src/Core/ApiClientCodeGen.Tests.Common/Fixtures/OpenApiCodeGeneratorFixture.cs
@@ -4,6 +4,7 @@ using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators.OpenApi;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.General;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.OpenApiGenerator;
 using Moq;
 
 namespace ApiClientCodeGen.Tests.Common.Fixtures
@@ -24,6 +25,7 @@ namespace ApiClientCodeGen.Tests.Common.Fixtures
                 Path.GetFullPath(SwaggerJsonFilename),
                 "GeneratedCode",
                 OptionsMock.Object,
+                new DefaultOpenApiGeneratorOptions(),
                 new ProcessLauncher(),
                 new DependencyInstaller(
                     new NpmInstaller(new ProcessLauncher()),

--- a/src/Core/ApiClientCodeGen.Tests.Common/Fixtures/Yaml/OpenApiCodeGeneratorFixture.cs
+++ b/src/Core/ApiClientCodeGen.Tests.Common/Fixtures/Yaml/OpenApiCodeGeneratorFixture.cs
@@ -4,6 +4,7 @@ using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators.OpenApi;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.General;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.OpenApiGenerator;
 using Moq;
 
 namespace ApiClientCodeGen.Tests.Common.Fixtures.Yaml
@@ -24,6 +25,7 @@ namespace ApiClientCodeGen.Tests.Common.Fixtures.Yaml
                 Path.GetFullPath(SwaggerYamlFilename),
                 "GeneratedCode",
                 OptionsMock.Object,
+                new DefaultOpenApiGeneratorOptions(),
                 new ProcessLauncher(),
                 new DependencyInstaller(
                     new NpmInstaller(new ProcessLauncher()),

--- a/src/VSIX/ApiClientCodeGen.Tests/Generators/CodeGeneratorFactoryTests.cs
+++ b/src/VSIX/ApiClientCodeGen.Tests/Generators/CodeGeneratorFactoryTests.cs
@@ -9,10 +9,12 @@ using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.AutoRest;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.General;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.NSwag;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.OpenApiGenerator;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Generators;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options.AutoRest;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options.General;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options.NSwag;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options.OpenApiGenerator;
 using FluentAssertions;
 using Moq;
 
@@ -38,6 +40,9 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Tests.Generator
             mockFactory
                 .Setup(c => c.Create<IAutoRestOptions, AutoRestOptionsPage>())
                 .Returns(Test.CreateDummy<IAutoRestOptions>());
+            mockFactory
+                .Setup(c => c.Create<IOpenApiGeneratorOptions, OpenApiGeneratorOptionsPage>())
+                .Returns(Test.CreateDummy<IOpenApiGeneratorOptions>());
 
             sut = new CodeGeneratorFactory(mockFactory.Object, null);
         }

--- a/src/VSIX/ApiClientCodeGen.Tests/Generators/OpenApi/OpenApiCSharpCodeGeneratorExceptionTests.cs
+++ b/src/VSIX/ApiClientCodeGen.Tests/Generators/OpenApi/OpenApiCSharpCodeGeneratorExceptionTests.cs
@@ -3,6 +3,7 @@ using ApiClientCodeGen.Tests.Common.Infrastructure;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators.OpenApi;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.OpenApiGenerator;
 using FluentAssertions;
 using Xunit;
 
@@ -11,60 +12,78 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Tests.Generator
     public class OpenApiCSharpCodeGeneratorExceptionTests
     {
         [Theory, AutoMoqData]
-        public void Constructor_Requires_SwaggerFile(IProcessLauncher launcher, IDependencyInstaller installer)
+        public void Constructor_Requires_SwaggerFile(
+            IProcessLauncher launcher,
+            IDependencyInstaller installer,
+            IOpenApiGeneratorOptions openApiGeneratorOptions)
             => new Action(
                     () => new OpenApiCSharpCodeGenerator(
                         null,
                         null,
                         null,
+                        openApiGeneratorOptions,
                         launcher,
                         installer))
                 .Should()
                 .ThrowExactly<ArgumentNullException>();
 
         [Theory, AutoMoqData]
-        public void Constructor_Requires_DefaultNamespace(IProcessLauncher launcher, IDependencyInstaller installer)
+        public void Constructor_Requires_DefaultNamespace(
+            IProcessLauncher launcher,
+            IDependencyInstaller installer,
+            IOpenApiGeneratorOptions openApiGeneratorOptions)
             => new Action(
                     () => new OpenApiCSharpCodeGenerator(
                         "",
                         null,
                         null,
+                        openApiGeneratorOptions,
                         launcher,
                         installer))
                 .Should()
                 .ThrowExactly<ArgumentNullException>();
 
         [Theory, AutoMoqData]
-        public void Constructor_Requires_Options(IProcessLauncher launcher, IDependencyInstaller installer)
+        public void Constructor_Requires_Options(
+            IProcessLauncher launcher,
+            IDependencyInstaller installer,
+            IOpenApiGeneratorOptions openApiGeneratorOptions)
             => new Action(
                     () => new OpenApiCSharpCodeGenerator(
                         "",
                         "",
                         null,
+                        openApiGeneratorOptions,
                         launcher,
                         installer))
                 .Should()
                 .ThrowExactly<ArgumentNullException>();
 
         [Theory, AutoMoqData]
-        public void Constructor_Requires_ProcessLauncher(IDependencyInstaller installer)
+        public void Constructor_Requires_ProcessLauncher(
+            IDependencyInstaller installer,
+            IOpenApiGeneratorOptions openApiGeneratorOptions)
             => new Action(
                     () => new OpenApiCSharpCodeGenerator(
                         "",
                         "",
                         null,
+                        openApiGeneratorOptions,
                         null,
                         installer))
                 .Should()
                 .ThrowExactly<ArgumentNullException>();
 
         [Theory, AutoMoqData]
-        public void Constructor_Requires_DependencyInstaller(IProcessLauncher launcher)
+        public void Constructor_Requires_DependencyInstaller(
+            IProcessLauncher launcher,
+            IOpenApiGeneratorOptions openApiGeneratorOptions)
             => new Action(
                     () => new OpenApiCSharpCodeGenerator(
                         "",
                         "",
                         null,
+                        openApiGeneratorOptions,
                         launcher,
                         null))
                 .Should()

--- a/src/VSIX/ApiClientCodeGen.Tests/Generators/OpenApi/OpenApiCSharpCodeGeneratorYamlTests.cs
+++ b/src/VSIX/ApiClientCodeGen.Tests/Generators/OpenApi/OpenApiCSharpCodeGeneratorYamlTests.cs
@@ -5,6 +5,7 @@ using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators.OpenApi;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.General;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.OpenApiGenerator;
 using Moq;
 
 namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Tests.Generators.OpenApi
@@ -12,6 +13,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Tests.Generator
     public class OpenApiCSharpCodeGeneratorYamlTests : TestWithResources
     {
         private readonly Mock<IGeneralOptions> optionsMock = new Mock<IGeneralOptions>();
+        private readonly Mock<IOpenApiGeneratorOptions> openApiGeneratorOptionsMock = new Mock<IOpenApiGeneratorOptions>();
         private readonly Mock<IProgressReporter> progressMock = new Mock<IProgressReporter>();
         private readonly Mock<IProcessLauncher> processMock = new Mock<IProcessLauncher>();
         private readonly Mock<IDependencyInstaller> dependencyMock = new Mock<IDependencyInstaller>();
@@ -21,6 +23,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Tests.Generator
                     SwaggerYamlFilename,
                     new Fixture().Create<string>(),
                     optionsMock.Object,
+                    openApiGeneratorOptionsMock.Object,
                     processMock.Object,
                     dependencyMock.Object)
                 .GenerateCode(progressMock.Object);

--- a/src/VSIX/ApiClientCodeGen.VSIX/ApiClientCodeGen.VSIX.csproj
+++ b/src/VSIX/ApiClientCodeGen.VSIX/ApiClientCodeGen.VSIX.csproj
@@ -100,6 +100,10 @@
     <Compile Include="Options\NSwag\NSwagOptionsPage.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="Options\OpenApiGenerator\OpenApiGeneratorOptions.cs" />
+    <Compile Include="Options\OpenApiGenerator\OpenApiGeneratorOptionsPage.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="Options\OptionsBase.cs" />
     <Compile Include="Options\General\CustomPathOptions.cs" />
     <Compile Include="Options\NSwagStudio\NSwagStudioOptions.cs" />

--- a/src/VSIX/ApiClientCodeGen.VSIX/Generators/CodeGeneratorFactory.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX/Generators/CodeGeneratorFactory.cs
@@ -17,6 +17,7 @@ using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options.AutoRest;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options.General;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options.NSwag;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options.OpenApiGenerator;
 using OpenApiDocumentFactory =
     ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Generators.NSwag.OpenApiDocumentFactory;
 
@@ -88,7 +89,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Generators
                         inputFilePath,
                         defaultNamespace,
                         optionsFactory.Create<IGeneralOptions, GeneralOptionPage>(),
-                        optionsFactory.Create<IOpenApiGeneratorOptions, GeneralOptionPage>(),
+                        optionsFactory.Create<IOpenApiGeneratorOptions, OpenApiGeneratorOptionsPage>(),
                         processLauncher,
                         dependencyInstaller);
 

--- a/src/VSIX/ApiClientCodeGen.VSIX/Generators/CodeGeneratorFactory.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX/Generators/CodeGeneratorFactory.cs
@@ -12,6 +12,7 @@ using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.AutoRest;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.General;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.NSwag;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.OpenApiGenerator;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options.AutoRest;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options.General;
@@ -87,6 +88,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Generators
                         inputFilePath,
                         defaultNamespace,
                         optionsFactory.Create<IGeneralOptions, GeneralOptionPage>(),
+                        optionsFactory.Create<IOpenApiGeneratorOptions, GeneralOptionPage>(),
                         processLauncher,
                         dependencyInstaller);
 

--- a/src/VSIX/ApiClientCodeGen.VSIX/Options/OpenApiGenerator/OpenApiGeneratorOptions.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX/Options/OpenApiGenerator/OpenApiGeneratorOptions.cs
@@ -29,6 +29,6 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options.OpenApi
             }
         }
 
-        public bool EmitDefaultValue { get; }
+        public bool EmitDefaultValue { get; set; }
     }
 }

--- a/src/VSIX/ApiClientCodeGen.VSIX/Options/OpenApiGenerator/OpenApiGeneratorOptions.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX/Options/OpenApiGenerator/OpenApiGeneratorOptions.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Diagnostics;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Logging;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.OpenApiGenerator;
+
+namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options.OpenApiGenerator
+{
+    public class OpenApiGeneratorOptions : OptionsBase<IOpenApiGeneratorOptions, OpenApiGeneratorOptionsPage>, IOpenApiGeneratorOptions
+    {
+        public OpenApiGeneratorOptions(IOpenApiGeneratorOptions options)
+        {
+            try
+            {
+                if (options == null)
+                    options = GetFromDialogPage();
+
+                EmitDefaultValue = options.EmitDefaultValue;
+            }
+            catch (Exception e)
+            {
+                Logger.Instance.TrackError(e);
+                
+                Trace.WriteLine(e);
+                Trace.WriteLine(Environment.NewLine);
+                Trace.WriteLine("Error reading user options. Reverting to default values");
+                Trace.WriteLine($"EmitDefaultValue = {EmitDefaultValue}");
+
+                EmitDefaultValue = true;
+            }
+        }
+
+        public bool EmitDefaultValue { get; }
+    }
+}

--- a/src/VSIX/ApiClientCodeGen.VSIX/Options/OpenApiGenerator/OpenApiGeneratorOptionsPage.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX/Options/OpenApiGenerator/OpenApiGeneratorOptionsPage.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.OpenApiGenerator;
+using Microsoft.VisualStudio.Shell;
+
+namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options.OpenApiGenerator
+{
+    [ExcludeFromCodeCoverage]
+    public class OpenApiGeneratorOptionsPage : DialogPage, IOpenApiGeneratorOptions
+    {
+        public const string Name = "OpenAPI Generator";
+        
+        [Category(Name)]
+        [DisplayName("Emit Default Value")]
+        [Description("Set to true if the default value for a member should be generated in the serialization stream")]
+        public bool EmitDefaultValue { get; set; }
+    }
+}

--- a/src/VSIX/ApiClientCodeGen.VSIX/Options/OpenApiGenerator/OpenApiGeneratorOptionsPage.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX/Options/OpenApiGenerator/OpenApiGeneratorOptionsPage.cs
@@ -9,10 +9,13 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options.OpenApi
     public class OpenApiGeneratorOptionsPage : DialogPage, IOpenApiGeneratorOptions
     {
         public const string Name = "OpenAPI Generator";
-        
+
         [Category(Name)]
         [DisplayName("Emit Default Value")]
-        [Description("Set to true if the default value for a member should be generated in the serialization stream")]
-        public bool EmitDefaultValue { get; set; }
+        [Description("Set to true if the default value for a member should be generated in the serialization stream. " +
+                     "Setting the EmitDefaultValue property to false is not a recommended practice. " +
+                     "It should only be done if there is a specific need to do so " +
+                     "(such as for interoperability or to reduce data size).")]
+        public bool EmitDefaultValue { get; set; } = true;
     }
 }

--- a/src/VSIX/ApiClientCodeGen.VSIX/Options/OpenApiGenerator/OpenApiGeneratorOptionsPage.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX/Options/OpenApiGenerator/OpenApiGeneratorOptionsPage.cs
@@ -12,10 +12,10 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options.OpenApi
 
         [Category(Name)]
         [DisplayName("Emit Default Value")]
-        [Description("Set to true if the default value for a member should be generated in the serialization stream. " +
-                     "Setting the EmitDefaultValue property to false is not a recommended practice. " +
-                     "It should only be done if there is a specific need to do so " +
-                     "(such as for interoperability or to reduce data size).")]
+        [Description("Set to True if the default value for a member should be generated in the serialization stream. " +
+                     "Setting this to False is not a recommended practice. " +
+                     "It should only be done if there is a specific need to do so, " +
+                     "such as for interoperability or to reduce data size.")]
         public bool EmitDefaultValue { get; set; } = true;
     }
 }

--- a/src/VSIX/ApiClientCodeGen.VSIX/VSPackage.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX/VSPackage.cs
@@ -12,6 +12,7 @@ using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options.AutoRest;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options.General;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options.NSwag;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options.NSwagStudio;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options.OpenApiGenerator;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Windows;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -69,6 +70,13 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient
         typeof(AnalyticsOptionPage),
         VsixName,
         AnalyticsOptionPage.Name,
+        0,
+        0,
+        true)]
+    [ProvideOptionPage(
+        typeof(OpenApiGeneratorOptionsPage),
+        VsixName,
+        OpenApiGeneratorOptionsPage.Name,
         0,
         0,
         true)]

--- a/src/VSIX/ApiClientCodegen.IntegrationTests/CustomTool/CSharpSingleFileCodeGeneratorOpenApi3Tests.cs
+++ b/src/VSIX/ApiClientCodegen.IntegrationTests/CustomTool/CSharpSingleFileCodeGeneratorOpenApi3Tests.cs
@@ -7,10 +7,12 @@ using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.AutoRest;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.General;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.NSwag;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.OpenApiGenerator;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Generators;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options.AutoRest;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options.General;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options.NSwag;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options.OpenApiGenerator;
 using FluentAssertions;
 using Microsoft.VisualStudio.Shell.Interop;
 using Moq;
@@ -69,10 +71,15 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.IntegrationTest
         public void OpenApi_CSharp_Test()
         {
             var optionsMock = new Mock<IGeneralOptions>();
+            var openApiOptionsMock = new Mock<IOpenApiGeneratorOptions>();
             var optionsFactory = new Mock<IOptionsFactory>();
             optionsFactory
                 .Setup(c => c.Create<IGeneralOptions, GeneralOptionPage>())
                 .Returns(optionsMock.Object);
+            
+            optionsFactory
+                .Setup(c => c.Create<IOpenApiGeneratorOptions, OpenApiGeneratorOptionsPage>())
+                .Returns(openApiOptionsMock.Object);
 
             Assert(SupportedCodeGenerator.OpenApi, optionsFactory.Object);
         }

--- a/src/VSIX/ApiClientCodegen.IntegrationTests/CustomTool/CSharpSingleFileCodeGeneratorOpenApi3YamlTests.cs
+++ b/src/VSIX/ApiClientCodegen.IntegrationTests/CustomTool/CSharpSingleFileCodeGeneratorOpenApi3YamlTests.cs
@@ -7,10 +7,12 @@ using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.AutoRest;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.General;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.NSwag;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.OpenApiGenerator;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Generators;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options.AutoRest;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options.General;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options.NSwag;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options.OpenApiGenerator;
 using FluentAssertions;
 using Microsoft.VisualStudio.Shell.Interop;
 using Moq;
@@ -69,10 +71,15 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.IntegrationTest
         public void OpenApi_CSharp_Test()
         {
             var optionsMock = new Mock<IGeneralOptions>();
+            var openApiOptionsMock = new Mock<IOpenApiGeneratorOptions>();
             var optionsFactory = new Mock<IOptionsFactory>();
             optionsFactory
                 .Setup(c => c.Create<IGeneralOptions, GeneralOptionPage>())
                 .Returns(optionsMock.Object);
+            
+            optionsFactory
+                .Setup(c => c.Create<IOpenApiGeneratorOptions, OpenApiGeneratorOptionsPage>())
+                .Returns(openApiOptionsMock.Object);
 
             Assert(SupportedCodeGenerator.OpenApi, optionsFactory.Object);
         }

--- a/src/VSIX/ApiClientCodegen.IntegrationTests/CustomTool/CSharpSingleFileCodeGeneratorTests.cs
+++ b/src/VSIX/ApiClientCodegen.IntegrationTests/CustomTool/CSharpSingleFileCodeGeneratorTests.cs
@@ -7,10 +7,12 @@ using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.AutoRest;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.General;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.NSwag;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.OpenApiGenerator;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Generators;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options.AutoRest;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options.General;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options.NSwag;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options.OpenApiGenerator;
 using FluentAssertions;
 using Microsoft.VisualStudio.Shell.Interop;
 using Moq;
@@ -69,10 +71,15 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.IntegrationTest
         public void OpenApi_CSharp_Test()
         {
             var optionsMock = new Mock<IGeneralOptions>();
+            var openApiOptionsMock = new Mock<IOpenApiGeneratorOptions>();
             var optionsFactory = new Mock<IOptionsFactory>();
             optionsFactory
                 .Setup(c => c.Create<IGeneralOptions, GeneralOptionPage>())
                 .Returns(optionsMock.Object);
+            
+            optionsFactory
+                .Setup(c => c.Create<IOpenApiGeneratorOptions, OpenApiGeneratorOptionsPage>())
+                .Returns(openApiOptionsMock.Object);
 
             Assert(SupportedCodeGenerator.OpenApi, optionsFactory.Object);
         }

--- a/src/VSIX/ApiClientCodegen.IntegrationTests/CustomTool/CSharpSingleFileCodeGeneratorYamlTests.cs
+++ b/src/VSIX/ApiClientCodegen.IntegrationTests/CustomTool/CSharpSingleFileCodeGeneratorYamlTests.cs
@@ -6,9 +6,11 @@ using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.AutoRest;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.General;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.OpenApiGenerator;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Generators;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options.AutoRest;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options.General;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Options.OpenApiGenerator;
 using FluentAssertions;
 using Microsoft.VisualStudio.Shell.Interop;
 using Moq;
@@ -47,10 +49,15 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.IntegrationTest
         public void OpenApi_CSharp_Test()
         {
             var optionsMock = new Mock<IGeneralOptions>();
+            var openApiOptionsMock = new Mock<IOpenApiGeneratorOptions>();
             var optionsFactory = new Mock<IOptionsFactory>();
             optionsFactory
                 .Setup(c => c.Create<IGeneralOptions, GeneralOptionPage>())
                 .Returns(optionsMock.Object);
+            
+            optionsFactory
+                .Setup(c => c.Create<IOpenApiGeneratorOptions, OpenApiGeneratorOptionsPage>())
+                .Returns(openApiOptionsMock.Object);
 
             Assert(SupportedCodeGenerator.OpenApi, optionsFactory.Object);
         }

--- a/src/VSMac/ApiClientCodeGen.VSMac/Container.cs
+++ b/src/VSMac/ApiClientCodeGen.VSMac/Container.cs
@@ -16,6 +16,7 @@ using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.AutoRe
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.General;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.NSwag;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.NSwagStudio;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.OpenApiGenerator;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace ApiClientCodeGen.VSMac
@@ -43,6 +44,7 @@ namespace ApiClientCodeGen.VSMac
             services.AddSingleton<INSwagOptions, DefaultNSwagOptions>();
             services.AddSingleton<INSwagStudioOptions, DefaultNSwagStudioOptions>();
             services.AddSingleton<IAutoRestOptions, DefaultAutoRestOptions>();
+            services.AddSingleton<IOpenApiGeneratorOptions, DefaultOpenApiGeneratorOptions>();
             services.AddSingleton<IProcessLauncher, ProcessLauncher>();
 
             services.AddSingleton<INSwagStudioCodeGeneratorFactory, NSwagStudioCodeGeneratorFactory>();

--- a/src/VSMac/ApiClientCodeGen.VSMac/CustomTools/OpenApi/OpenApiGeneratorFactory.cs
+++ b/src/VSMac/ApiClientCodeGen.VSMac/CustomTools/OpenApi/OpenApiGeneratorFactory.cs
@@ -2,6 +2,7 @@ using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators.OpenApi;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.General;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.OpenApiGenerator;
 
 namespace ApiClientCodeGen.VSMac.CustomTools.OpenApi
 {
@@ -10,23 +11,25 @@ namespace ApiClientCodeGen.VSMac.CustomTools.OpenApi
         ICodeGenerator Create(
             string swaggerFile,
             string defaultNamespace,
-            IGeneralOptions options,
+            IGeneralOptions generalOptions,
+            IOpenApiGeneratorOptions openApiGeneratorOptions,
             IProcessLauncher processLauncher,
             IDependencyInstaller dependencyInstaller);
     }
 
     public class OpenApiGeneratorFactory : IOpenApiGeneratorFactory
     {
-        public ICodeGenerator Create(
-            string swaggerFile,
+        public ICodeGenerator Create(string swaggerFile,
             string defaultNamespace,
-            IGeneralOptions options,
+            IGeneralOptions generalOptions,
+            IOpenApiGeneratorOptions openApiGeneratorOptions,
             IProcessLauncher processLauncher,
             IDependencyInstaller dependencyInstaller)
             => new OpenApiCSharpCodeGenerator(
                 swaggerFile,
                 defaultNamespace,
-                options,
+                generalOptions,
+                openApiGeneratorOptions,
                 processLauncher,
                 dependencyInstaller);
     }

--- a/src/VSMac/ApiClientCodeGen.VSMac/CustomTools/OpenApi/OpenApiSingleFileCustomTool.cs
+++ b/src/VSMac/ApiClientCodeGen.VSMac/CustomTools/OpenApi/OpenApiSingleFileCustomTool.cs
@@ -2,6 +2,7 @@ using System;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.General;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.OpenApiGenerator;
 
 namespace ApiClientCodeGen.VSMac.CustomTools.OpenApi
 {
@@ -10,6 +11,7 @@ namespace ApiClientCodeGen.VSMac.CustomTools.OpenApi
         public const string GeneratorName = "OpenApiCodeGenerator";
 
         private readonly IGeneralOptions options;
+        private readonly IOpenApiGeneratorOptions openApiGeneratorOptions;
         private readonly IProcessLauncher processLauncher;
         private readonly IOpenApiGeneratorFactory factory;
         private readonly IDependencyInstaller dependencyInstaller;
@@ -17,6 +19,7 @@ namespace ApiClientCodeGen.VSMac.CustomTools.OpenApi
         public OpenApiSingleFileCustomTool()
             : this(
                 Container.Instance.Resolve<IGeneralOptions>(),
+                Container.Instance.Resolve<IOpenApiGeneratorOptions>(),
                 Container.Instance.Resolve<IProcessLauncher>(),
                 Container.Instance.Resolve<IOpenApiGeneratorFactory>(),
                 Container.Instance.Resolve<IDependencyInstaller>())
@@ -25,11 +28,13 @@ namespace ApiClientCodeGen.VSMac.CustomTools.OpenApi
 
         public OpenApiSingleFileCustomTool(
             IGeneralOptions options,
+            IOpenApiGeneratorOptions openApiGeneratorOptions,
             IProcessLauncher processLauncher,
             IOpenApiGeneratorFactory factory,
             IDependencyInstaller dependencyInstaller)
         {
             this.options = options ?? throw new ArgumentNullException(nameof(options));
+            this.openApiGeneratorOptions = openApiGeneratorOptions ?? throw new ArgumentNullException(nameof(openApiGeneratorOptions));
             this.processLauncher = processLauncher ?? throw new ArgumentNullException(nameof(processLauncher));
             this.factory = factory ?? throw new ArgumentNullException(nameof(factory));
             this.dependencyInstaller = dependencyInstaller ?? throw new ArgumentNullException(nameof(dependencyInstaller));
@@ -42,6 +47,7 @@ namespace ApiClientCodeGen.VSMac.CustomTools.OpenApi
                 swaggerFile,
                 customToolNamespace,
                 options,
+                openApiGeneratorOptions,
                 processLauncher,
                 dependencyInstaller);
     }

--- a/src/VSMac/ApiClientCodeGen.VSMac/Makefile
+++ b/src/VSMac/ApiClientCodeGen.VSMac/Makefile
@@ -3,11 +3,11 @@
 all: debug release
 	
 restore-packages: 
-	nuget restore ApiClientCodeGen.VSMac.sln
+	nuget restore ApiClientCodeGen.VSMac.csproj
 
 debug: restore-packages
-	msbuild /p:Configuration="Debug" /t:"Rebuild" ApiClientCodeGen.VSMac.sln
+	msbuild /p:Configuration="Debug" /t:"Rebuild" ApiClientCodeGen.VSMac.csproj
 
 release: restore-packages
-	msbuild /p:Configuration="Release" /t:"Rebuild" ApiClientCodeGen.VSMac.sln
-	mono /Applications/Visual\ Studio.app/Contents/Resources/lib/monodevelop/bin/vstool.exe setup pack bin/Release/net471/ApiClientCodeGen.VSMac.dll
+	msbuild /p:Configuration="Release" /t:"Rebuild" ApiClientCodeGen.VSMac.csproj
+	mono /Applications/Visual\ Studio.app/Contents/Resources/lib/monodevelop/bin/vstool.exe setup pack bin/Release/net472/ApiClientCodeGen.VSMac.dll


### PR DESCRIPTION
This pull request implements a Visual Studio options page that allows users to change how OpenAPI Generator generates code. This currently only supports the `EmitDefaultValue` option. 

This change adds `--additional-properties optionalEmitDefaultValues=true|false` to the arguments passed to the OpenAPI Generator CLI tool

Resolves issue #246 