### PR TITLE
Restructure CLI Tool commands

### DIFF
--- a/.github/workflows/production-tests.yml
+++ b/.github/workflows/production-tests.yml
@@ -66,7 +66,7 @@ jobs:
 
     - name: Generate code with AutoRest
       run: |
-        rapicgen -v autorest ./OpenApi.${{ matrix.format }} GeneratedCode ./GeneratedCode/AutoRest-${{ matrix.version }}/Output.cs --no-logging
+        rapicgen -v csharp autorest ./OpenApi.${{ matrix.format }} GeneratedCode ./GeneratedCode/AutoRest-${{ matrix.version }}/Output.cs --no-logging
         cp ./GeneratedCode/AutoRest-${{ matrix.version }}/Output.cs ./GeneratedCode/AutoRest-${{ matrix.version }}/NetCore21/Output.cs
         cp ./GeneratedCode/AutoRest-${{ matrix.version }}/Output.cs ./GeneratedCode/AutoRest-${{ matrix.version }}/NetCore31/Output.cs
         cp ./GeneratedCode/AutoRest-${{ matrix.version }}/Output.cs ./GeneratedCode/AutoRest-${{ matrix.version }}/Net5/Output.cs
@@ -124,7 +124,7 @@ jobs:
 
     - name: Generate code with NSwag
       run: |
-        rapicgen -v nswag ./OpenApi.${{ matrix.format }} GeneratedCode ./GeneratedCode/NSwag/Output.cs --no-logging
+        rapicgen -v csharp nswag ./OpenApi.${{ matrix.format }} GeneratedCode ./GeneratedCode/NSwag/Output.cs --no-logging
         cp ./GeneratedCode/NSwag/Output.cs ./GeneratedCode/NSwag/NetCore21/Output.cs
         cp ./GeneratedCode/NSwag/Output.cs ./GeneratedCode/NSwag/NetCore31/Output.cs
         cp ./GeneratedCode/NSwag/Output.cs ./GeneratedCode/NSwag/Net5/Output.cs
@@ -179,7 +179,7 @@ jobs:
 
     - name: Generate code with Swagger Codegen CLI
       run: |
-        rapicgen -v swagger ./OpenApi.${{ matrix.format }} GeneratedCode ./GeneratedCode/SwaggerCodegen/Output.cs --no-logging
+        rapicgen -v csharp swagger ./OpenApi.${{ matrix.format }} GeneratedCode ./GeneratedCode/SwaggerCodegen/Output.cs --no-logging
         cp ./GeneratedCode/SwaggerCodegen/Output.cs ./GeneratedCode/SwaggerCodegen/NetCore21/Output.cs
         cp ./GeneratedCode/SwaggerCodegen/Output.cs ./GeneratedCode/SwaggerCodegen/NetCore31/Output.cs
         cp ./GeneratedCode/SwaggerCodegen/Output.cs ./GeneratedCode/SwaggerCodegen/Net5/Output.cs
@@ -238,7 +238,7 @@ jobs:
 
     - name: Generate code with OpenAPI Generator
       run: |
-        rapicgen -v openapi ./OpenApi.${{ matrix.format }} GeneratedCode ./GeneratedCode/OpenApiGenerator/Output.cs --no-logging
+        rapicgen -v csharp openapi ./OpenApi.${{ matrix.format }} GeneratedCode ./GeneratedCode/OpenApiGenerator/Output.cs --no-logging
         cp ./GeneratedCode/OpenApiGenerator/Output.cs ./GeneratedCode/OpenApiGenerator/NetCore21/Output.cs
         cp ./GeneratedCode/OpenApiGenerator/Output.cs ./GeneratedCode/OpenApiGenerator/NetCore31/Output.cs
         cp ./GeneratedCode/OpenApiGenerator/Output.cs ./GeneratedCode/OpenApiGenerator/Net5/Output.cs
@@ -341,7 +341,7 @@ jobs:
 
     - name: Generate JMeter
       run: |
-        rapicgen -v apache-jmeter ./OpenApi.${{ matrix.format }} --no-logging
+        rapicgen -v jmeter ./OpenApi.${{ matrix.format }} --no-logging
       working-directory: test
 
   TypeScript:

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -66,7 +66,7 @@ jobs:
 
     - name: Generate code with AutoRest
       run: |
-        dotnet run --project ../src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -- -v autorest ./OpenApi.${{ matrix.format }} GeneratedCode ./GeneratedCode/AutoRest-${{ matrix.version }}/Output.cs --no-logging
+        dotnet run --project ../src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -- -v csharp autorest ./OpenApi.${{ matrix.format }} GeneratedCode ./GeneratedCode/AutoRest-${{ matrix.version }}/Output.cs --no-logging
         cp ./GeneratedCode/AutoRest-${{ matrix.version }}/Output.cs ./GeneratedCode/AutoRest-${{ matrix.version }}/NetCore21/Output.cs
         cp ./GeneratedCode/AutoRest-${{ matrix.version }}/Output.cs ./GeneratedCode/AutoRest-${{ matrix.version }}/NetCore31/Output.cs
         cp ./GeneratedCode/AutoRest-${{ matrix.version }}/Output.cs ./GeneratedCode/AutoRest-${{ matrix.version }}/Net5/Output.cs
@@ -124,7 +124,7 @@ jobs:
 
     - name: Generate code with NSwag
       run: |
-        dotnet run --project ../src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -- -v nswag ./OpenApi.${{ matrix.format }} GeneratedCode ./GeneratedCode/NSwag/Output.cs --no-logging
+        dotnet run --project ../src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -- -v csharp nswag ./OpenApi.${{ matrix.format }} GeneratedCode ./GeneratedCode/NSwag/Output.cs --no-logging
         cp ./GeneratedCode/NSwag/Output.cs ./GeneratedCode/NSwag/NetCore21/Output.cs
         cp ./GeneratedCode/NSwag/Output.cs ./GeneratedCode/NSwag/NetCore31/Output.cs
         cp ./GeneratedCode/NSwag/Output.cs ./GeneratedCode/NSwag/Net5/Output.cs
@@ -179,7 +179,7 @@ jobs:
 
     - name: Generate code with Swagger Codegen CLI
       run: |
-        dotnet run --project ../src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -- -v swagger ./OpenApi.${{ matrix.format }} GeneratedCode ./GeneratedCode/SwaggerCodegen/Output.cs --no-logging
+        dotnet run --project ../src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -- -v csharp swagger ./OpenApi.${{ matrix.format }} GeneratedCode ./GeneratedCode/SwaggerCodegen/Output.cs --no-logging
         cp ./GeneratedCode/SwaggerCodegen/Output.cs ./GeneratedCode/SwaggerCodegen/NetCore21/Output.cs
         cp ./GeneratedCode/SwaggerCodegen/Output.cs ./GeneratedCode/SwaggerCodegen/NetCore31/Output.cs
         cp ./GeneratedCode/SwaggerCodegen/Output.cs ./GeneratedCode/SwaggerCodegen/Net5/Output.cs
@@ -238,7 +238,7 @@ jobs:
 
     - name: Generate code with OpenAPI Generator
       run: |
-        dotnet run --project ../src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -- -v openapi ./OpenApi.${{ matrix.format }} GeneratedCode ./GeneratedCode/OpenApiGenerator/Output.cs --no-logging
+        dotnet run --project ../src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -- -v csharp openapi ./OpenApi.${{ matrix.format }} GeneratedCode ./GeneratedCode/OpenApiGenerator/Output.cs --no-logging
         cp ./GeneratedCode/OpenApiGenerator/Output.cs ./GeneratedCode/OpenApiGenerator/NetCore21/Output.cs
         cp ./GeneratedCode/OpenApiGenerator/Output.cs ./GeneratedCode/OpenApiGenerator/NetCore31/Output.cs
         cp ./GeneratedCode/OpenApiGenerator/Output.cs ./GeneratedCode/OpenApiGenerator/Net5/Output.cs
@@ -338,7 +338,7 @@ jobs:
 
     - name: Generate JMeter
       run: |
-        dotnet run --project ../src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -- -v apache-jmeter ./OpenApi.${{ matrix.format }} --no-logging
+        dotnet run --project ../src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -- -v jmeter ./OpenApi.${{ matrix.format }} --no-logging
       working-directory: test
 
   TypeScript:

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -60,7 +60,7 @@ jobs:
 
     - name: Generate code with AutoRest
       run: |
-        dotnet run --project ../src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -- -v autorest ./OpenApi.${{ matrix.format }} GeneratedCode ./GeneratedCode/AutoRest-${{ matrix.version }}/Output.cs --no-logging
+        dotnet run --project ../src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -- -v csharp autorest ./OpenApi.${{ matrix.format }} GeneratedCode ./GeneratedCode/AutoRest-${{ matrix.version }}/Output.cs --no-logging
         cp ./GeneratedCode/AutoRest-${{ matrix.version }}/Output.cs ./GeneratedCode/AutoRest-${{ matrix.version }}/NetCore21/Output.cs
         cp ./GeneratedCode/AutoRest-${{ matrix.version }}/Output.cs ./GeneratedCode/AutoRest-${{ matrix.version }}/NetCore31/Output.cs
         cp ./GeneratedCode/AutoRest-${{ matrix.version }}/Output.cs ./GeneratedCode/AutoRest-${{ matrix.version }}/Net5/Output.cs
@@ -118,7 +118,7 @@ jobs:
 
     - name: Generate code with NSwag
       run: |
-        dotnet run --project ../src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -- -v nswag ./OpenApi.${{ matrix.format }} GeneratedCode ./GeneratedCode/NSwag/Output.cs --no-logging
+        dotnet run --project ../src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -- -v csharp nswag ./OpenApi.${{ matrix.format }} GeneratedCode ./GeneratedCode/NSwag/Output.cs --no-logging
         cp ./GeneratedCode/NSwag/Output.cs ./GeneratedCode/NSwag/NetCore21/Output.cs
         cp ./GeneratedCode/NSwag/Output.cs ./GeneratedCode/NSwag/NetCore31/Output.cs
         cp ./GeneratedCode/NSwag/Output.cs ./GeneratedCode/NSwag/Net5/Output.cs
@@ -173,7 +173,7 @@ jobs:
 
     - name: Generate code with Swagger Codegen CLI
       run: |
-        dotnet run --project ../src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -- -v swagger ./OpenApi.${{ matrix.format }} GeneratedCode ./GeneratedCode/SwaggerCodegen/Output.cs --no-logging
+        dotnet run --project ../src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -- -v csharp swagger ./OpenApi.${{ matrix.format }} GeneratedCode ./GeneratedCode/SwaggerCodegen/Output.cs --no-logging
         cp ./GeneratedCode/SwaggerCodegen/Output.cs ./GeneratedCode/SwaggerCodegen/NetCore21/Output.cs
         cp ./GeneratedCode/SwaggerCodegen/Output.cs ./GeneratedCode/SwaggerCodegen/NetCore31/Output.cs
         cp ./GeneratedCode/SwaggerCodegen/Output.cs ./GeneratedCode/SwaggerCodegen/Net5/Output.cs
@@ -232,7 +232,7 @@ jobs:
 
     - name: Generate code with OpenAPI Generator
       run: |
-        dotnet run --project ../src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -- -v openapi ./OpenApi.${{ matrix.format }} GeneratedCode ./GeneratedCode/OpenApiGenerator/Output.cs --no-logging
+        dotnet run --project ../src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -- -v csharp openapi ./OpenApi.${{ matrix.format }} GeneratedCode ./GeneratedCode/OpenApiGenerator/Output.cs --no-logging
         cp ./GeneratedCode/OpenApiGenerator/Output.cs ./GeneratedCode/OpenApiGenerator/NetCore21/Output.cs
         cp ./GeneratedCode/OpenApiGenerator/Output.cs ./GeneratedCode/OpenApiGenerator/NetCore31/Output.cs
         cp ./GeneratedCode/OpenApiGenerator/Output.cs ./GeneratedCode/OpenApiGenerator/Net5/Output.cs
@@ -323,7 +323,7 @@ jobs:
 
     - name: Generate JMeter
       run: |
-        dotnet run --project ../src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -- -v apache-jmeter ./OpenApi.${{ matrix.format }} --no-logging
+        dotnet run --project ../src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -- -v jmeter ./OpenApi.${{ matrix.format }} --no-logging
       working-directory: test
 
   TypeScript:

--- a/README.md
+++ b/README.md
@@ -123,11 +123,11 @@ This extension collects errors and tracks feature usages to a service called [Ex
 ![NSwag Studio Context Menu](images/vsmac-nswag-studio.png)
 
 
-## Installation
+# Installation
 
 The Visual Studio extension can be installed directly from Visual Studio 2017 or 2019 via the **Extensions Dialog Box**. The process is best described in the official Microsoft documentation for [Managing extensions for Visual Studio](https://docs.microsoft.com/en-us/visualstudio/ide/finding-and-using-visual-studio-extensions?view=vs-2019)
 
-### Visual Studio for Mac
+## Visual Studio for Mac
 
 This installation process for **Visual Studio for Mac** is currently a bit troublesome as the MonoDevelop Addin Repository is currently not accepting new users so I can't really register and setup my extension.
 
@@ -197,7 +197,7 @@ Here's what you need to do:
 ![Manually uninstall Add-in](images/vsmac-extensions-uninstall.png)
 
 
-## Cross Platform Command Line Tool
+# Cross Platform Command Line Tool
 All custom tools mentioned above are also implemented in a cross platform command line application
 
 #### Requirements
@@ -220,19 +220,15 @@ The help information is displayed when not specifying any arguments to **rapicge
 Usage: rapicgen [command] [options]
 
 Options:
-  -v|--verbose   Show verbose output
-  -?|-h|--help   Show help information.
+  -v|--verbose  Show verbose output
+  -?|-h|--help  Show help information.
 
 Commands:
-  apache-jmeter  Generate Apache JMeter test plans
-  autorest       Generate C# API client using AutoRest
-  nswag          Generate C# API client using NSwag
-  openapi        Generate C# API client using OpenAPI Generator
-  swagger        Generate C# API client using Swagger Codegen CLI
-  typescript     Generate TypeScript API client
+  csharp        Generate C# API client
+  jmeter        Generate Apache JMeter test plans
+  typescript    Generate TypeScript API client
 
 Run 'rapicgen [command] -?|-h|--help' for more information about a command.
-
 ```
 
 Some help information is also provided per command and can be launched by 
@@ -241,10 +237,41 @@ Some help information is also provided per command and can be launched by
 rapicgen [command name] -?
 ```
 
+or
+
+```
+rapicgen [command name] [sub command name] -?
+```
+
 For example:
 
 ```
-rapicgen autorest -?
+rapicgen csharp -?
+``` 
+
+will output this:
+
+```
+Generate C# API client
+
+Usage: rapicgen csharp [command] [options]
+
+Options:
+  -?|-h|--help  Show help information.
+
+Commands:
+  autorest      Generate C# API client using AutoRest
+  nswag         Generate C# API client using NSwag
+  openapi       Generate C# API client using OpenAPI Generator
+  swagger       Generate C# API client using Swagger Codegen CLI
+
+Run 'csharp [command] -?|-h|--help' for more information about a command.
+```
+
+and
+
+```
+rapicgen csharp autorest -?
 ```
 
 will output this:
@@ -309,34 +336,34 @@ dotnet tool install --global rapicgen
 Here's an example of how to generate code using **AutoRest**
 
 ```
-rapicgen autorest Swagger.json GeneratedCode ./AutoRestOutput.cs
+rapicgen csharp autorest Swagger.json GeneratedCode ./AutoRestOutput.cs
 ```
 
 Here's an example of how to generate code using **NSwag**
 
 ```
-rapicgen nswag Swagger.json GeneratedCode ./NSwagOutput.cs
+rapicgen csharp nswag Swagger.json GeneratedCode ./NSwagOutput.cs
 ```
 
 Here's an example of how to generate code using **Swagger Codegen CLI**
 
 ```
-rapicgen swagger Swagger.json GeneratedCode ./SwaggerOutput.cs
+rapicgen csharp swagger Swagger.json GeneratedCode ./SwaggerOutput.cs
 ```
 
 Here's an example of how to generate code using **OpenAPI Generator**
 
 ```
-rapicgen openapi Swagger.json GeneratedCode ./OpenApiOutput.cs
+rapicgen csharp openapi Swagger.json GeneratedCode ./OpenApiOutput.cs
 ```
 
-Here's an example of how to generate code JMeter test plans
+Here's an example of how to generate code **JMeter** test plans
 
 ```
-rapicgen apache-jmeter Swagger.json
+rapicgen jmeter Swagger.json
 ```
 
-Here's an example of how to generate code for TypeScript
+Here's an example of how to generate code for **TypeScript**
 
 ```
 rapicgen typescript Angular Swagger.json

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -21,19 +21,15 @@ The help information is displayed when not specifying any arguments to **rapicge
 Usage: rapicgen [command] [options]
 
 Options:
-  -v|--verbose   Show verbose output
-  -?|-h|--help   Show help information.
+  -v|--verbose  Show verbose output
+  -?|-h|--help  Show help information.
 
 Commands:
-  apache-jmeter  Generate Apache JMeter test plans
-  autorest       Generate C# API client using AutoRest
-  nswag          Generate C# API client using NSwag
-  openapi        Generate C# API client using OpenAPI Generator
-  swagger        Generate C# API client using Swagger Codegen CLI
-  typescript     Generate TypeScript API client
+  csharp        Generate C# API client
+  jmeter        Generate Apache JMeter test plans
+  typescript    Generate TypeScript API client
 
 Run 'rapicgen [command] -?|-h|--help' for more information about a command.
-
 ```
 
 Some help information is also provided per command and can be launched by 
@@ -42,10 +38,41 @@ Some help information is also provided per command and can be launched by
 rapicgen [command name] -?
 ```
 
+or
+
+```
+rapicgen [command name] [sub command name] -?
+```
+
 For example:
 
 ```
-rapicgen autorest -?
+rapicgen csharp -?
+``` 
+
+will output this:
+
+```
+Generate C# API client
+
+Usage: rapicgen csharp [command] [options]
+
+Options:
+  -?|-h|--help  Show help information.
+
+Commands:
+  autorest      Generate C# API client using AutoRest
+  nswag         Generate C# API client using NSwag
+  openapi       Generate C# API client using OpenAPI Generator
+  swagger       Generate C# API client using Swagger Codegen CLI
+
+Run 'csharp [command] -?|-h|--help' for more information about a command.
+```
+
+and
+
+```
+rapicgen csharp autorest -?
 ```
 
 will output this:
@@ -110,34 +137,34 @@ dotnet tool install --global rapicgen
 Here's an example of how to generate code using **AutoRest**
 
 ```
-rapicgen autorest Swagger.json GeneratedCode ./AutoRestOutput.cs
+rapicgen csharp autorest Swagger.json GeneratedCode ./AutoRestOutput.cs
 ```
 
 Here's an example of how to generate code using **NSwag**
 
 ```
-rapicgen nswag Swagger.json GeneratedCode ./NSwagOutput.cs
+rapicgen csharp nswag Swagger.json GeneratedCode ./NSwagOutput.cs
 ```
 
 Here's an example of how to generate code using **Swagger Codegen CLI**
 
 ```
-rapicgen swagger Swagger.json GeneratedCode ./SwaggerOutput.cs
+rapicgen csharp swagger Swagger.json GeneratedCode ./SwaggerOutput.cs
 ```
 
 Here's an example of how to generate code using **OpenAPI Generator**
 
 ```
-rapicgen openapi Swagger.json GeneratedCode ./OpenApiOutput.cs
+rapicgen csharp openapi Swagger.json GeneratedCode ./OpenApiOutput.cs
 ```
 
-Here's an example of how to generate code JMeter test plans
+Here's an example of how to generate code **JMeter** test plans
 
 ```
-rapicgen apache-jmeter Swagger.json
+rapicgen jmeter Swagger.json
 ```
 
-Here's an example of how to generate code for TypeScript
+Here's an example of how to generate code for **TypeScript**
 
 ```
 rapicgen typescript Angular Swagger.json

--- a/src/CLI/ApiClientCodeGen.CLI/Commands/CSharpCommand.cs
+++ b/src/CLI/ApiClientCodeGen.CLI/Commands/CSharpCommand.cs
@@ -5,7 +5,7 @@ using McMaster.Extensions.CommandLineUtils;
 namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.CLI.Commands
 {
     [ExcludeFromCodeCoverage]
-    [Command("csharp", Description = "Generate C# API clients")]
+    [Command("csharp", Description = "Generate C# API client")]
     [Subcommand(
         typeof(AutoRestCommand),
         typeof(NSwagCommand),

--- a/src/CLI/ApiClientCodeGen.CLI/Commands/CSharpCommand.cs
+++ b/src/CLI/ApiClientCodeGen.CLI/Commands/CSharpCommand.cs
@@ -5,16 +5,14 @@ using McMaster.Extensions.CommandLineUtils;
 namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.CLI.Commands
 {
     [ExcludeFromCodeCoverage]
-    [Command]
+    [Command("csharp", Description = "Generate C# API clients")]
     [Subcommand(
-        typeof(CSharpCommand),
-        typeof(JMeterCommand),
-        typeof(TypeScriptCommand))]
-    public class RootCommand
+        typeof(AutoRestCommand),
+        typeof(NSwagCommand),
+        typeof(SwaggerCodegenCommand),
+        typeof(OpenApiGeneratorCommand))]
+    public class CSharpCommand
     {
-        [Option(VerboseOption.Template, CommandOptionType.NoValue, Description = VerboseOption.Description)]
-        public bool Verbose { get; set; }
-
         public int OnExecute(CommandLineApplication app)
         {
             app.ShowHelp(false);

--- a/src/CLI/ApiClientCodeGen.CLI/Commands/JMeterCommand.cs
+++ b/src/CLI/ApiClientCodeGen.CLI/Commands/JMeterCommand.cs
@@ -12,7 +12,7 @@ using McMaster.Extensions.CommandLineUtils;
 
 namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.CLI.Commands
 {
-    [Command("apache-jmeter", Description = "Generate Apache JMeter test plans")]
+    [Command("jmeter", Description = "Generate Apache JMeter test plans")]
     public class JMeterCommand
     {
         private readonly IConsoleOutput console;

--- a/test/utilities.ps1
+++ b/test/utilities.ps1
@@ -185,19 +185,19 @@ function Generate-Code {
 
     switch ($ToolName) {
         "SwaggerCodegen" {
-            $command = "swagger"
+            $command = "csharp swagger"
         }
         "OpenApiGenerator" { 
-            $command = "openapi"
+            $command = "csharp openapi"
         }
         "AutoRest-V2" {
-            $command = "autorest"
+            $command = "csharp autorest"
         } 
         "AutoRest-V3" {
-            $command = "autorest"
+            $command = "csharp autorest"
         }
         "NSwag" {
-            $command = "nswag"
+            $command = "csharp nswag"
         }
     }
 
@@ -256,10 +256,10 @@ function Generate-CodeParallel {
     "AutoRest-V2", "NSwag", "SwaggerCodegen", "OpenApiGenerator" | ForEach-Object {
         switch ($_) {
             "SwaggerCodegen" {
-                $command = "swagger"
+                $command = "csharp swagger"
             }
             "OpenApiGenerator" { 
-                $command = "openapi"
+                $command = "csharp openapi"
             }
             Default {
                 $command = $_.ToLower()


### PR DESCRIPTION
The changes here updates the structure of the CLI tool commands so that the code generates are grouped by language. 

The root command will now output the following:

```
Usage: rapicgen [command] [options]

Options:
  -v|--verbose  Show verbose output
  -?|-h|--help  Show help information.

Commands:
  csharp        Generate C# API client
  jmeter        Generate Apache JMeter test plans
  typescript    Generate TypeScript API client

Run 'rapicgen [command] -?|-h|--help' for more information about a command.
```

**Usage Examples:**

Let's say we have a OpenAPI Specifications document called **Swagger.json**

For starters, we can use the Swagger Petstore spec. Here's an example powershell script for downloading it

```
Invoke-WebRequest -Uri https://petstore.swagger.io/v2/swagger.json -OutFile Swagger.json
```

In case you don't have the CLI tool installed you can install it by

```
dotnet tool install --global rapicgen
```

Here's an example of how to generate code using **AutoRest**

```
rapicgen csharp autorest Swagger.json GeneratedCode ./AutoRestOutput.cs
```

Here's an example of how to generate code using **NSwag**

```
rapicgen csharp nswag Swagger.json GeneratedCode ./NSwagOutput.cs
```

Here's an example of how to generate code using **Swagger Codegen CLI**

```
rapicgen csharp swagger Swagger.json GeneratedCode ./SwaggerOutput.cs
```

Here's an example of how to generate code using **OpenAPI Generator**

```
rapicgen csharp openapi Swagger.json GeneratedCode ./OpenApiOutput.cs
```

Here's an example of how to generate code **JMeter** test plans

```
rapicgen jmeter Swagger.json
```

Here's an example of how to generate code for **TypeScript**

```
rapicgen typescript Angular Swagger.json
```