### PR TITLE
Add CLI Tool support for OpenAPI Generator pass through commands

### DIFF
--- a/src/CLI/ApiClientCodeGen.CLI.Tests/Command/OpenApiCSharpGeneratorCommandTests.cs
+++ b/src/CLI/ApiClientCodeGen.CLI.Tests/Command/OpenApiCSharpGeneratorCommandTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.CLI.Tests.Command
 {
-    public class OpenApiGeneratorCommandTests
+    public class OpenApiCSharpGeneratorCommandTests
     {   
         [Theory, AutoMoqData]
         public void DefaultNamespace_Should_NotBeNullOrWhiteSpace(OpenApiCSharpGeneratorCommand sut)

--- a/src/CLI/ApiClientCodeGen.CLI.Tests/Command/OpenApiCSharpGeneratorFactoryTests.cs
+++ b/src/CLI/ApiClientCodeGen.CLI.Tests/Command/OpenApiCSharpGeneratorFactoryTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.CLI.Tests.Command
 {
-    public class OpenApiGeneratorFactoryTests
+    public class OpenApiCSharpGeneratorFactoryTests
     {
         [Theory, AutoMoqData]
         public void Create_Should_Return_NotNull(

--- a/src/CLI/ApiClientCodeGen.CLI.Tests/Command/OpenApiGeneratorCommandTests.cs
+++ b/src/CLI/ApiClientCodeGen.CLI.Tests/Command/OpenApiGeneratorCommandTests.cs
@@ -1,0 +1,80 @@
+using System;
+using System.IO;
+using ApiClientCodeGen.Tests.Common.Infrastructure;
+using AutoFixture.Xunit2;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.CLI.Commands;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.General;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.CLI.Tests.Command
+{
+    public class OpenApiGeneratorCommandTests
+    {
+        [Theory, AutoMoqData]
+        public void OutputPath_Should_NotBeNullOrWhiteSpace(OpenApiGeneratorCommand sut)
+            => sut.OutputPath.Should().NotBeNullOrWhiteSpace();
+
+        [Theory, AutoMoqData]
+        public void SwaggerFile_Should_NotBeNullOrWhiteSpace(OpenApiGeneratorCommand sut)
+            => sut.SwaggerFile.Should().NotBeNullOrWhiteSpace();
+
+        [Theory, AutoMoqData]
+        public void OutputFile_Should_NotBeNullOrWhiteSpace(OpenApiGeneratorCommand sut)
+            => sut.OutputPath.Should().NotBeNullOrWhiteSpace();
+
+        [Theory, AutoMoqData]
+        public void OnExecuteAsync_Should_NotThrow(OpenApiGeneratorCommand sut)
+        {
+            sut.OutputPath = Directory.GetCurrentDirectory();
+            new Func<int>(sut.OnExecute).Should().NotThrow();
+        }
+
+        [Theory, AutoMoqData]
+        public void OnExecute_Should_Create_Generator(
+            [Frozen] IOpenApiGeneratorFactory factory,
+            OpenApiGeneratorCommand sut)
+        {
+            sut.OutputPath = Directory.GetCurrentDirectory();
+            sut.OnExecute();
+
+            Mock.Get(factory)
+                .Verify(
+                    c => c.Create(
+                        sut.Generator,
+                        sut.SwaggerFile,
+                        sut.OutputPath,
+                        It.IsAny<IGeneralOptions>(),
+                        It.IsAny<IProcessLauncher>(),
+                        It.IsAny<IDependencyInstaller>()));
+        }
+
+        [Theory, AutoMoqData]
+        public void OnExecute_Should_Write_To_IConsole(
+            [Frozen] IOpenApiGeneratorFactory factory,
+            OpenApiGeneratorCommand sut)
+        {
+            var path = Directory.CreateDirectory(
+                Path.Combine(
+                    Path.GetTempPath(),
+                    Guid.NewGuid().ToString("N")));
+
+            sut.OutputPath = path.FullName;
+            sut.SkipLogging = false;
+            sut.OnExecute();
+
+            Mock.Get(factory)
+                .Verify(
+                    c => c.Create(
+                        sut.Generator,
+                        sut.SwaggerFile,
+                        sut.OutputPath,
+                        It.IsAny<IGeneralOptions>(),
+                        It.IsAny<IProcessLauncher>(),
+                        It.IsAny<IDependencyInstaller>()));
+        }
+    }
+}

--- a/src/CLI/ApiClientCodeGen.CLI.Tests/Command/OpenApiGeneratorCommandTests.cs
+++ b/src/CLI/ApiClientCodeGen.CLI.Tests/Command/OpenApiGeneratorCommandTests.cs
@@ -13,26 +13,26 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.CLI.Tests.Comma
     public class OpenApiGeneratorCommandTests
     {   
         [Theory, AutoMoqData]
-        public void DefaultNamespace_Should_NotBeNullOrWhiteSpace(OpenApiGeneratorCommand sut)
+        public void DefaultNamespace_Should_NotBeNullOrWhiteSpace(OpenApiCSharpGeneratorCommand sut)
             => sut.DefaultNamespace.Should().NotBeNullOrWhiteSpace();
 
         [Theory, AutoMoqData]
-        public void SwaggerFile_Should_NotBeNullOrWhiteSpace(OpenApiGeneratorCommand sut)
+        public void SwaggerFile_Should_NotBeNullOrWhiteSpace(OpenApiCSharpGeneratorCommand sut)
             => sut.SwaggerFile.Should().NotBeNullOrWhiteSpace();
 
         [Theory, AutoMoqData]
-        public void OutputFile_Should_NotBeNullOrWhiteSpace(OpenApiGeneratorCommand sut)
+        public void OutputFile_Should_NotBeNullOrWhiteSpace(OpenApiCSharpGeneratorCommand sut)
             => sut.OutputFile.Should().NotBeNullOrWhiteSpace();
 
         [Theory, AutoMoqData]
-        public void CreateGenerator_Should_NotNull(OpenApiGeneratorCommand sut)
+        public void CreateGenerator_Should_NotNull(OpenApiCSharpGeneratorCommand sut)
             => sut.CreateGenerator().Should().NotBeNull();
 
         [Theory, AutoMoqData]
         public void OnExecuteAsync_Should_NotThrow(
             [Frozen] IProgressReporter progressReporter,
             [Frozen] ICodeGenerator generator,
-            OpenApiGeneratorCommand sut,
+            OpenApiCSharpGeneratorCommand sut,
             string code)
         {
             Mock.Get(generator)

--- a/src/CLI/ApiClientCodeGen.CLI.Tests/Command/OpenApiGeneratorFactoryTests.cs
+++ b/src/CLI/ApiClientCodeGen.CLI.Tests/Command/OpenApiGeneratorFactoryTests.cs
@@ -13,7 +13,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.CLI.Tests.Comma
     {
         [Theory, AutoMoqData]
         public void Create_Should_Return_NotNull(
-            OpenApiGeneratorFactory sut,
+            OpenApiCSharpGeneratorFactory sut,
             string swaggerFile,
             string defaultNamespace,
             IGeneralOptions options,

--- a/src/CLI/ApiClientCodeGen.CLI.Tests/Command/OpenApiGeneratorFactoryTests.cs
+++ b/src/CLI/ApiClientCodeGen.CLI.Tests/Command/OpenApiGeneratorFactoryTests.cs
@@ -1,0 +1,32 @@
+using ApiClientCodeGen.Tests.Common.Infrastructure;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.CLI.Commands;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.General;
+using FluentAssertions;
+using Xunit;
+
+namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.CLI.Tests.Command
+{
+    public class OpenApiGeneratorFactoryTests
+    {
+        [Theory, AutoMoqData]
+        public void Create_Should_Return_NotNull(
+            OpenApiGeneratorFactory sut,
+            string generator,
+            string swaggerFile,
+            string oututPath,
+            IGeneralOptions options,
+            IProcessLauncher processLauncher,
+            IDependencyInstaller dependencyInstaller)
+            => sut.Create(
+                    generator,
+                    swaggerFile,
+                    oututPath,
+                    options,
+                    processLauncher,
+                    dependencyInstaller)
+                .Should()
+                .NotBeNull();
+    }
+}

--- a/src/CLI/ApiClientCodeGen.CLI/Commands/CSharpCommand.cs
+++ b/src/CLI/ApiClientCodeGen.CLI/Commands/CSharpCommand.cs
@@ -10,7 +10,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.CLI.Commands
         typeof(AutoRestCommand),
         typeof(NSwagCommand),
         typeof(SwaggerCodegenCommand),
-        typeof(OpenApiGeneratorCommand))]
+        typeof(OpenApiCSharpGeneratorCommand))]
     public class CSharpCommand
     {
         public int OnExecute(CommandLineApplication app)

--- a/src/CLI/ApiClientCodeGen.CLI/Commands/OpenApiCSharpGeneratorCommand.cs
+++ b/src/CLI/ApiClientCodeGen.CLI/Commands/OpenApiCSharpGeneratorCommand.cs
@@ -10,27 +10,27 @@ using McMaster.Extensions.CommandLineUtils;
 namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.CLI.Commands
 {
     [Command("openapi", Description = "Generate C# API client using OpenAPI Generator")]
-    public class OpenApiGeneratorCommand : CodeGeneratorCommand, IOpenApiGeneratorOptions
+    public class OpenApiCSharpGeneratorCommand : CodeGeneratorCommand, IOpenApiGeneratorOptions
     {
         private readonly IGeneralOptions options;
         private readonly IOpenApiGeneratorOptions openApiGeneratorOptions;
         private readonly IProcessLauncher processLauncher;
-        private readonly IOpenApiGeneratorFactory generatorFactory;
+        private readonly IOpenApiCSharpGeneratorFactory cSharpGeneratorFactory;
         private readonly IDependencyInstaller dependencyInstaller;
 
-        public OpenApiGeneratorCommand(
+        public OpenApiCSharpGeneratorCommand(
             IConsoleOutput console,
             IProgressReporter? progressReporter,
             IGeneralOptions options,
             IOpenApiGeneratorOptions openApiGeneratorOptions,
             IProcessLauncher processLauncher,
-            IOpenApiGeneratorFactory generatorFactory,
+            IOpenApiCSharpGeneratorFactory cSharpGeneratorFactory,
             IDependencyInstaller dependencyInstaller) : base(console, progressReporter)
         {
             this.options = options ?? throw new ArgumentNullException(nameof(options));
             this.openApiGeneratorOptions = openApiGeneratorOptions;
             this.processLauncher = processLauncher ?? throw new ArgumentNullException(nameof(processLauncher));
-            this.generatorFactory = generatorFactory ?? throw new ArgumentNullException(nameof(generatorFactory));
+            this.cSharpGeneratorFactory = cSharpGeneratorFactory ?? throw new ArgumentNullException(nameof(cSharpGeneratorFactory));
             this.dependencyInstaller = dependencyInstaller ?? throw new ArgumentNullException(nameof(dependencyInstaller));
         }
 
@@ -108,7 +108,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.CLI.Commands
         }
 
         public override ICodeGenerator CreateGenerator()
-            => generatorFactory.Create(
+            => cSharpGeneratorFactory.Create(
                 SwaggerFile,
                 DefaultNamespace,
                 options,

--- a/src/CLI/ApiClientCodeGen.CLI/Commands/OpenApiCSharpGeneratorFactory.cs
+++ b/src/CLI/ApiClientCodeGen.CLI/Commands/OpenApiCSharpGeneratorFactory.cs
@@ -6,7 +6,7 @@ using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.OpenAp
 
 namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.CLI.Commands
 {
-    public interface IOpenApiGeneratorFactory
+    public interface IOpenApiCSharpGeneratorFactory
     {
         ICodeGenerator Create(
             string swaggerFile,
@@ -17,7 +17,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.CLI.Commands
             IDependencyInstaller dependencyInstaller);
     }
 
-    public class OpenApiGeneratorFactory : IOpenApiGeneratorFactory
+    public class OpenApiCSharpGeneratorFactory : IOpenApiCSharpGeneratorFactory
     {
         public ICodeGenerator Create(
             string swaggerFile,

--- a/src/CLI/ApiClientCodeGen.CLI/Commands/OpenApiGeneratorCommand.cs
+++ b/src/CLI/ApiClientCodeGen.CLI/Commands/OpenApiGeneratorCommand.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.CLI.Extensions;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Logging;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.General;
+using McMaster.Extensions.CommandLineUtils;
+
+namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.CLI.Commands
+{
+    [ExcludeFromCodeCoverage]
+    [Command(
+        "openapi-generator", 
+        Description = 
+            @"Generate code using OpenAPI Generator. 
+See supported generators at https://openapi-generator.tech/docs/generators/")]
+    public class OpenApiGeneratorCommand
+    {
+        private readonly IConsoleOutput console;
+        private readonly IProgressReporter? progressReporter;
+        private readonly IGeneralOptions options;
+        private readonly IOpenApiGeneratorFactory factory;
+        private readonly IProcessLauncher processLauncher;
+        private readonly IDependencyInstaller dependencyInstaller;
+
+        private string? outputPath;
+
+        public OpenApiGeneratorCommand(
+            IConsoleOutput console,
+            IProgressReporter progressReporter,
+            IGeneralOptions options,
+            IOpenApiGeneratorFactory factory,
+            IProcessLauncher processLauncher,
+            IDependencyInstaller dependencyInstaller)
+        {
+            this.console = console ?? throw new ArgumentNullException(nameof(console));
+            this.progressReporter = progressReporter ?? throw new ArgumentNullException(nameof(progressReporter));
+            this.options = options ?? throw new ArgumentNullException(nameof(options));
+            this.factory = factory;
+            this.processLauncher = processLauncher ?? throw new ArgumentNullException(nameof(processLauncher));
+            this.dependencyInstaller =
+                dependencyInstaller ?? throw new ArgumentNullException(nameof(dependencyInstaller));
+        }
+
+        [Required]
+        [Argument(
+            0,
+            "generator",
+            Description = 
+                @"The tech stack to use for generating code.
+See supported generators at https://openapi-generator.tech/docs/generators/")] 
+        public string Generator { get; set; } = null!;
+
+        [Required]
+        [FileExists]
+        [Argument(1, "swaggerFile", "Path to the Swagger / Open API specification file")]
+        [SuppressMessage("ReSharper", "AutoPropertyCanBeMadeGetOnly.Global")]
+        public string SwaggerFile { get; set; } = null!;
+
+        [Argument(2, "outputPath", "Output folder to write the generated code to")]
+        public string OutputPath
+        {
+            get => outputPath ?? $"{Generator}-generated-code";
+            set => outputPath = value;
+        }
+
+        [Option(ShortName = "nl", LongName = "no-logging", Description = "Disables Analytics and Error Reporting")]
+        public bool SkipLogging { get; set; }
+
+        public int OnExecute()
+        {
+            if (!SkipLogging)
+            {
+                Logger.Instance.TrackFeatureUsage(
+                    $"openapi-generator {Generator}",
+                    "CLI");
+            }
+            else
+            {
+                Logger.Instance.Disable();
+                console.WriteLine("NOTE: Feature usage tracking and error Logging is disabled");
+            }
+
+
+            factory
+                .Create(Generator, SwaggerFile, OutputPath, options, processLauncher, dependencyInstaller)
+                .GenerateCode(progressReporter);
+
+            var directoryInfo = new DirectoryInfo(OutputPath);
+            var fileCount = directoryInfo.GetFiles().Length;
+            if (fileCount != 0)
+            {
+                console.WriteLine($"Output folder name: {OutputPath}");
+                console.WriteLine($"Output files: {fileCount}");
+                console.WriteSignature();
+            }
+            else
+            {
+                const string errorMessage = "ERROR!! Output folder is empty :(";
+                console.WriteLine(errorMessage);
+                console.WriteLine(string.Empty);
+
+                if (!SkipLogging)
+                    Logger.Instance.TrackError(new Exception(errorMessage));
+            }
+
+            return fileCount != 0 ? ResultCodes.Success : ResultCodes.Error;
+        }
+    }
+}

--- a/src/CLI/ApiClientCodeGen.CLI/Commands/OpenApiGeneratorCommand.cs
+++ b/src/CLI/ApiClientCodeGen.CLI/Commands/OpenApiGeneratorCommand.cs
@@ -12,7 +12,6 @@ using McMaster.Extensions.CommandLineUtils;
 
 namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.CLI.Commands
 {
-    [ExcludeFromCodeCoverage]
     [Command(
         "openapi-generator", 
         Description = 

--- a/src/CLI/ApiClientCodeGen.CLI/Commands/OpenApiGeneratorFactory.cs
+++ b/src/CLI/ApiClientCodeGen.CLI/Commands/OpenApiGeneratorFactory.cs
@@ -1,0 +1,36 @@
+﻿using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators.OpenApi;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.General;
+
+namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.CLI.Commands
+{
+    public interface IOpenApiGeneratorFactory
+    {
+        ICodeGenerator Create(
+            string generator,
+            string swaggerFile,
+            string outputPath,
+            IGeneralOptions options,
+            IProcessLauncher processLauncher,
+            IDependencyInstaller dependencyInstaller);
+    }
+
+    public class OpenApiGeneratorFactory : IOpenApiGeneratorFactory
+    {
+        public ICodeGenerator Create(
+            string generator,
+            string swaggerFile,
+            string outputPath,
+            IGeneralOptions options,
+            IProcessLauncher processLauncher,
+            IDependencyInstaller dependencyInstaller)
+            => new OpenApiCodeGenerator(
+                swaggerFile,
+                outputPath,
+                generator,
+                options,
+                processLauncher,
+                dependencyInstaller);
+    }
+}

--- a/src/CLI/ApiClientCodeGen.CLI/Commands/RootCommand.cs
+++ b/src/CLI/ApiClientCodeGen.CLI/Commands/RootCommand.cs
@@ -9,7 +9,8 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.CLI.Commands
     [Subcommand(
         typeof(CSharpCommand),
         typeof(JMeterCommand),
-        typeof(TypeScriptCommand))]
+        typeof(TypeScriptCommand),
+        typeof(OpenApiGeneratorCommand))]
     public class RootCommand
     {
         [Option(VerboseOption.Template, CommandOptionType.NoValue, Description = VerboseOption.Description)]

--- a/src/CLI/ApiClientCodeGen.CLI/Extensions/CodeGeneratorNameExtensions.cs
+++ b/src/CLI/ApiClientCodeGen.CLI/Extensions/CodeGeneratorNameExtensions.cs
@@ -10,7 +10,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.CLI.Extensions
         {
             var type = generator.GetType();
             
-            if (type == typeof(OpenApiGeneratorCommand))
+            if (type == typeof(OpenApiCSharpGeneratorCommand))
                 return SupportedCodeGenerator.OpenApi.GetName();
             
             if (type == typeof(SwaggerCodegenCommand))

--- a/src/CLI/ApiClientCodeGen.CLI/Program.cs
+++ b/src/CLI/ApiClientCodeGen.CLI/Program.cs
@@ -65,6 +65,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.CLI
             services.AddSingleton<IOpenApiDocumentFactory, OpenApiDocumentFactory>();
             services.AddSingleton<INSwagCodeGeneratorSettingsFactory, NSwagCodeGeneratorSettingsFactory>();
             services.AddSingleton<IProcessLauncher, ProcessLauncher>();
+            services.AddSingleton<IOpenApiGeneratorFactory, OpenApiGeneratorFactory>();
             services.AddSingleton<IJMeterCodeGeneratorFactory, JMeterCodeGeneratorFactory>();
             services.AddSingleton<ITypeScriptCodeGeneratorFactory, TypeScriptCodeGeneratorFactory>();
             services.AddSingleton<IAutoRestCodeGeneratorFactory, AutoRestCodeGeneratorFactory>();

--- a/src/CLI/ApiClientCodeGen.CLI/Program.cs
+++ b/src/CLI/ApiClientCodeGen.CLI/Program.cs
@@ -69,7 +69,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.CLI
             services.AddSingleton<ITypeScriptCodeGeneratorFactory, TypeScriptCodeGeneratorFactory>();
             services.AddSingleton<IAutoRestCodeGeneratorFactory, AutoRestCodeGeneratorFactory>();
             services.AddSingleton<INSwagCodeGeneratorFactory, NSwagCodeGeneratorFactory>();
-            services.AddSingleton<IOpenApiGeneratorFactory, OpenApiGeneratorFactory>();
+            services.AddSingleton<IOpenApiCSharpGeneratorFactory, OpenApiCSharpGeneratorFactory>();
             services.AddSingleton<ISwaggerCodegenFactory, SwaggerCodegenFactory>();
             services.AddSingleton<IDependencyInstaller, DependencyInstaller>();
             services.AddSingleton<INpmInstaller, NpmInstaller>();

--- a/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiCodeGenerator.cs
@@ -6,7 +6,7 @@ using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.Genera
 
 namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators.OpenApi
 {
-    public abstract class OpenApiCodeGenerator : ICodeGenerator
+    public class OpenApiCodeGenerator : ICodeGenerator
     {
         private readonly JavaPathProvider javaPathProvider;
         private readonly IGeneralOptions options;
@@ -16,7 +16,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
         private readonly string outputPath;
         private readonly string generator;
 
-        protected OpenApiCodeGenerator(
+        public OpenApiCodeGenerator(
             string swaggerFile,
             string outputPath,
             string generator,

--- a/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiCodeGenerator.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.General;
+
+namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators.OpenApi
+{
+    public abstract class OpenApiCodeGenerator : ICodeGenerator
+    {
+        private readonly JavaPathProvider javaPathProvider;
+        private readonly IGeneralOptions options;
+        private readonly IProcessLauncher processLauncher;
+        private readonly IDependencyInstaller dependencyInstaller;
+        private readonly string swaggerFile;
+        private readonly string outputPath;
+        private readonly string generator;
+
+        protected OpenApiCodeGenerator(
+            string swaggerFile,
+            string outputPath,
+            string generator,
+            IGeneralOptions options,
+            IProcessLauncher processLauncher,
+            IDependencyInstaller dependencyInstaller)
+        {
+            this.swaggerFile = swaggerFile;
+            this.outputPath = outputPath ?? throw new ArgumentNullException(nameof(outputPath));
+            this.generator = generator;
+            this.options = options ?? throw new ArgumentNullException(nameof(options));
+            this.processLauncher = processLauncher ?? throw new ArgumentNullException(nameof(processLauncher));
+            this.dependencyInstaller = dependencyInstaller ?? throw new ArgumentNullException(nameof(dependencyInstaller));
+            javaPathProvider = new JavaPathProvider(options, processLauncher);
+        }
+
+        public string GenerateCode(IProgressReporter? pGenerateProgress)
+        {
+            try
+            {
+                pGenerateProgress?.Progress(10);
+
+                var jarFile = options.OpenApiGeneratorPath;
+                if (!File.Exists(jarFile))
+                {
+                    Trace.WriteLine(jarFile + " does not exist");
+                    jarFile = dependencyInstaller.InstallOpenApiGenerator();
+                }
+
+                pGenerateProgress?.Progress(30);
+
+                var output = Path.Combine(
+                    Path.GetDirectoryName(swaggerFile) ?? throw new InvalidOperationException(),
+                    outputPath);
+
+                Directory.CreateDirectory(output);
+                pGenerateProgress?.Progress(40);
+
+                var arguments =
+                    $"-jar \"{jarFile}\" generate " +
+                    $"--generator-name {GetGeneratorName()} " +
+                    $"--input-spec \"{Path.GetFileName(swaggerFile)}\" " +
+                    $"--output \"{output}\" ";
+
+
+                processLauncher.Start(
+                    javaPathProvider.GetJavaExePath(),
+                    arguments,
+                    Path.GetDirectoryName(swaggerFile));
+
+                pGenerateProgress?.Progress(80);
+            }
+            finally
+            {
+                pGenerateProgress?.Progress(90);
+            }
+
+            return string.Empty;
+        }
+
+        protected virtual string GetGeneratorName() => generator;
+    }
+}

--- a/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiJMeterCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiJMeterCodeGenerator.cs
@@ -1,77 +1,18 @@
-﻿using System;
-using System.Diagnostics;
-using System.IO;
-using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer;
+﻿using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.General;
 
 namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators.OpenApi
 {
-    public class OpenApiJMeterCodeGenerator : ICodeGenerator
+    public class OpenApiJMeterCodeGenerator : OpenApiCodeGenerator
     {
-        private readonly JavaPathProvider javaPathProvider;
-        private readonly IGeneralOptions options;
-        private readonly IProcessLauncher processLauncher;
-        private readonly IDependencyInstaller dependencyInstaller;
-        private readonly string swaggerFile;
-        private readonly string outputPath;
-
         public OpenApiJMeterCodeGenerator(
             string swaggerFile,
             string outputPath,
             IGeneralOptions options,
             IProcessLauncher processLauncher,
             IDependencyInstaller dependencyInstaller)
+            : base(swaggerFile, outputPath, "jmeter", options, processLauncher, dependencyInstaller)
         {
-            this.swaggerFile = swaggerFile;
-            this.outputPath = outputPath ?? throw new ArgumentNullException(nameof(outputPath));
-            this.options = options ?? throw new ArgumentNullException(nameof(options));
-            this.processLauncher = processLauncher ?? throw new ArgumentNullException(nameof(processLauncher));
-            this.dependencyInstaller = dependencyInstaller ?? throw new ArgumentNullException(nameof(dependencyInstaller));
-            javaPathProvider = new JavaPathProvider(options, processLauncher);
-        }
-
-        public string GenerateCode(IProgressReporter? pGenerateProgress)
-        {
-            try
-            {
-                pGenerateProgress?.Progress(10);
-
-                var jarFile = options.OpenApiGeneratorPath;
-                if (!File.Exists(jarFile))
-                {
-                    Trace.WriteLine(jarFile + " does not exist");
-                    jarFile = dependencyInstaller.InstallOpenApiGenerator();
-                }
-
-                pGenerateProgress?.Progress(30);
-
-                var output = Path.Combine(
-                    Path.GetDirectoryName(swaggerFile) ?? throw new InvalidOperationException(),
-                    outputPath);
-
-                Directory.CreateDirectory(output);
-                pGenerateProgress?.Progress(40);
-
-                var arguments =
-                    $"-jar \"{jarFile}\" generate " +
-                    "--generator-name jmeter " +
-                    $"--input-spec \"{Path.GetFileName(swaggerFile)}\" " +
-                    $"--output \"{output}\" ";
-
-
-                processLauncher.Start(
-                    javaPathProvider.GetJavaExePath(),
-                    arguments,
-                    Path.GetDirectoryName(swaggerFile));
-
-                pGenerateProgress?.Progress(80);
-            }
-            finally
-            {
-                pGenerateProgress?.Progress(90);
-            }
-
-            return string.Empty;
         }
     }
 }

--- a/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiTypeScriptCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiTypeScriptCodeGenerator.cs
@@ -1,19 +1,10 @@
-﻿using System;
-using System.Diagnostics;
-using System.IO;
-using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer;
+﻿using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.General;
 
 namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators.OpenApi
 {
-    public class OpenApiTypeScriptCodeGenerator : ICodeGenerator
+    public class OpenApiTypeScriptCodeGenerator : OpenApiCodeGenerator
     {
-        private readonly JavaPathProvider javaPathProvider;
-        private readonly IGeneralOptions options;
-        private readonly IProcessLauncher processLauncher;
-        private readonly IDependencyInstaller dependencyInstaller;
-        private readonly string swaggerFile;
-        private readonly string outputPath;
         private readonly OpenApiTypeScriptGenerator typeScriptGenerator;
 
         public OpenApiTypeScriptCodeGenerator(
@@ -23,65 +14,16 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
             IGeneralOptions options,
             IProcessLauncher processLauncher,
             IDependencyInstaller dependencyInstaller)
+            : base(swaggerFile, outputPath, null!, options, processLauncher, dependencyInstaller)
         {
-            this.swaggerFile = swaggerFile;
-            this.outputPath = outputPath ?? throw new ArgumentNullException(nameof(outputPath));
             this.typeScriptGenerator = typeScriptGenerator;
-            this.options = options ?? throw new ArgumentNullException(nameof(options));
-            this.processLauncher = processLauncher ?? throw new ArgumentNullException(nameof(processLauncher));
-            this.dependencyInstaller = dependencyInstaller ?? throw new ArgumentNullException(nameof(dependencyInstaller));
-            javaPathProvider = new JavaPathProvider(options, processLauncher);
         }
 
-        public string GenerateCode(IProgressReporter? pGenerateProgress)
-        {
-            try
-            {
-                pGenerateProgress?.Progress(10);
-
-                var jarFile = options.OpenApiGeneratorPath;
-                if (!File.Exists(jarFile))
-                {
-                    Trace.WriteLine(jarFile + " does not exist");
-                    jarFile = dependencyInstaller.InstallOpenApiGenerator();
-                }
-
-                pGenerateProgress?.Progress(30);
-
-                var output = Path.Combine(
-                    Path.GetDirectoryName(swaggerFile) ?? throw new InvalidOperationException(),
-                    outputPath);
-
-                Directory.CreateDirectory(output);
-                pGenerateProgress?.Progress(40);
-
-                var arguments =
-                    $"-jar \"{jarFile}\" generate " +
-                    $"--generator-name {GetGeneratorName(typeScriptGenerator)} " +
-                    $"--input-spec \"{Path.GetFileName(swaggerFile)}\" " +
-                    $"--output \"{output}\" ";
-
-
-                processLauncher.Start(
-                    javaPathProvider.GetJavaExePath(),
-                    arguments,
-                    Path.GetDirectoryName(swaggerFile));
-
-                pGenerateProgress?.Progress(80);
-            }
-            finally
-            {
-                pGenerateProgress?.Progress(90);
-            }
-
-            return string.Empty;
-        }
-
-        private static string GetGeneratorName(OpenApiTypeScriptGenerator openApiTypeScriptGenerator)
-            => openApiTypeScriptGenerator switch
+        protected override string GetGeneratorName()
+            => typeScriptGenerator switch
             {
                 OpenApiTypeScriptGenerator.ReduxQuery => "typescript-redux-query",
-                _ => "typescript-" + openApiTypeScriptGenerator.ToString().ToLower()
+                _ => "typescript-" + typeScriptGenerator.ToString().ToLower()
             };
     }
 }


### PR DESCRIPTION
The changes here add the `openapi-generator` command to rapicgen for generating code any supported generator by OpenAPI Generator behind the scenes.

```
Usage: rapicgen [command] [options]

Options:
  -v|--verbose       Show verbose output
  -?|-h|--help       Show help information.

Commands:
  csharp             Generate C# API client
  jmeter             Generate Apache JMeter test plans
  openapi-generator  Generate code using OpenAPI Generator.
                     See supported generators at https://openapi-generator.tech/docs/generators/
  typescript         Generate TypeScript API client

Run 'rapicgen [command] -?|-h|--help' for more information about a command.
```