### PR TITLE
Track Dependency Failures in Application Insights

### DIFF
--- a/src/CLI/ApiClientCodeGen.CLI/SentryRemoteLogger.cs
+++ b/src/CLI/ApiClientCodeGen.CLI/SentryRemoteLogger.cs
@@ -44,6 +44,11 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.CLI
             SentrySdk.CaptureException(exception);
         }
 
+        public void TrackDependencyFailure(string dependencyName)
+        {
+            // Not implemented
+        }
+
         public void Disable()
         {
             SentrySdk.Close();

--- a/src/Core/ApiClientCodeGen.Core/Generators/AutoRest/AutoRestCSharpCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/AutoRest/AutoRestCSharpCodeGenerator.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators.NSwag;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Logging;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.AutoRest;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.General;
 
@@ -112,6 +113,11 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
 
                     return FileHelper.ReadThenDelete(outputFile);
                 }
+            }
+            catch
+            {
+                Logger.Instance.TrackDependencyFailure("AutoRest");
+                throw;
             }
             finally
             {

--- a/src/Core/ApiClientCodeGen.Core/Generators/NSwag/NSwagCSharpCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/NSwag/NSwagCSharpCodeGenerator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Logging;
 using NSwag.CodeGeneration.CSharp;
 
 namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators.NSwag
@@ -33,6 +34,11 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
                 pGenerateProgress?.Progress(50);
                 var generator = new CSharpClientGenerator(document, settings);
                 return generator.GenerateFile();
+            }
+            catch
+            {
+                Logger.Instance.TrackDependencyFailure("NSwag");
+                throw;
             }
             finally
             {

--- a/src/Core/ApiClientCodeGen.Core/Generators/NSwagStudio/NSwagStudioCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/NSwagStudio/NSwagStudioCodeGenerator.cs
@@ -46,7 +46,16 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
                 pGenerateProgress?.Progress(50);
 
                 var arguments = $"run \"{nswagStudioFile}\"";
-                processLauncher.Start(command, arguments, Path.GetDirectoryName(nswagStudioFile)!); 
+
+                try
+                {
+                    processLauncher.Start(command, arguments, Path.GetDirectoryName(nswagStudioFile)!); 
+                }
+                catch
+                {
+                    Logger.Instance.TrackDependencyFailure("NSwag Studio");
+                    throw;
+                }
             }
             
             pGenerateProgress?.Progress(100);

--- a/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiCSharpCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiCSharpCodeGenerator.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Extensions;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Logging;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.General;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.OpenApiGenerator;
 
@@ -99,6 +100,11 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
                 pGenerateProgress?.Progress(80);
 
                 return CSharpFileMerger.MergeFilesAndDeleteSource(output);
+            }
+            catch
+            {
+                Logger.Instance.TrackDependencyFailure("OpenAPI Generator");
+                throw;
             }
             finally
             {

--- a/src/Core/ApiClientCodeGen.Core/Generators/Swagger/SwaggerCSharpCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/Swagger/SwaggerCSharpCodeGenerator.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.IO;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Logging;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.General;
 
 namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators.Swagger
@@ -65,6 +66,11 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
                 pGenerateProgress?.Progress(80);
 
                 return CSharpFileMerger.MergeFilesAndDeleteSource(output);
+            }
+            catch
+            {
+                Logger.Instance.TrackDependencyFailure("Swagger Codegen CLI");
+                throw;
             }
             finally
             {

--- a/src/Core/ApiClientCodeGen.Core/Installer/NpmInstaller.cs
+++ b/src/Core/ApiClientCodeGen.Core/Installer/NpmInstaller.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Logging;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.General;
 
 namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer
@@ -18,11 +19,19 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer
         {
             Trace.WriteLine($"Attempting to install {packageName} through NPM");
 
-            processLauncher.Start(
-                PathProvider.GetNpmPath(),
-                $"install -g {packageName}");
+            try
+            {
+                processLauncher.Start(
+                    PathProvider.GetNpmPath(),
+                    $"install -g {packageName}");
 
-            Trace.WriteLine($"{packageName} installed successfully through NPM");
+                Trace.WriteLine($"{packageName} installed successfully through NPM");
+            }
+            catch
+            {
+                Logger.Instance.TrackDependencyFailure($"npm install -g {packageName}");
+                throw;
+            }
         }
     }
 }

--- a/src/Core/ApiClientCodeGen.Core/Installer/WebDownloader.cs
+++ b/src/Core/ApiClientCodeGen.Core/Installer/WebDownloader.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Threading;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Logging;
 
 namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer
 {
@@ -10,14 +11,21 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer
     {
         public void DownloadFile(string address, string filename)
         {
-            using var mutex = new Mutex(false, nameof(WebDownloader));
-            if (!mutex.WaitOne(TimeSpan.FromMinutes(2)))
-                throw new TimeoutException();
+            try
+            {
+                using var mutex = new Mutex(false, nameof(WebDownloader));
+                if (!mutex.WaitOne(TimeSpan.FromMinutes(2)))
+                    throw new TimeoutException();
 
-            using var client = new WebClient();
-            client.DownloadFile(address, filename);
+                using var client = new WebClient();
+                client.DownloadFile(address, filename);
             
-            mutex.ReleaseMutex();
+                mutex.ReleaseMutex();
+            }
+            catch
+            {
+                Logger.Instance.TrackDependencyFailure($"GET {address}");
+            }
         }
     }
 }

--- a/src/Core/ApiClientCodeGen.Core/Logging/AppInsightsRemoteLogger.cs
+++ b/src/Core/ApiClientCodeGen.Core/Logging/AppInsightsRemoteLogger.cs
@@ -43,6 +43,14 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Logging
             telemetryClient.Flush();
         }
 
+        public void TrackDependencyFailure(string dependencyName)
+        {
+            if (TestingUtility.IsRunningFromUnitTest || Debugger.IsAttached)
+                return;
+            telemetryClient.TrackDependency(new DependencyTelemetry { Name = dependencyName });
+            telemetryClient.Flush();
+        }
+
         public void Disable()
         {
             telemetryClient.TelemetryConfiguration.DisableTelemetry = true;

--- a/src/Core/ApiClientCodeGen.Core/Logging/ExceptionlessRemoteLogger.cs
+++ b/src/Core/ApiClientCodeGen.Core/Logging/ExceptionlessRemoteLogger.cs
@@ -66,6 +66,11 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Logging
             exception.ToExceptionless().Submit();
         }
 
+        public void TrackDependencyFailure(string dependencyName)
+        {
+            // Not implemented
+        }
+
         public void Disable()
         {
             ExceptionlessClient.Default.Configuration.Enabled = false;

--- a/src/Core/ApiClientCodeGen.Core/Logging/IRemoteLogger.cs
+++ b/src/Core/ApiClientCodeGen.Core/Logging/IRemoteLogger.cs
@@ -6,6 +6,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Logging
     {
         void TrackFeatureUsage(string featureName, params string[] tags);
         void TrackError(Exception exception);
+        void TrackDependencyFailure(string dependencyName);
         void Disable();
     }
 }

--- a/src/Core/ApiClientCodeGen.Core/Logging/RemoteLogger.cs
+++ b/src/Core/ApiClientCodeGen.Core/Logging/RemoteLogger.cs
@@ -37,6 +37,12 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Logging
                 logger.TrackError(exception);
         }
 
+        public void TrackDependencyFailure(string dependencyName)
+        {
+            foreach (var logger in Loggers)
+                logger.TrackDependencyFailure(dependencyName);
+        }
+
         public void Disable() 
             => Loggers.ForEach(c=>c.Disable());
     }

--- a/src/Core/ApiClientCodeGen.Core/NpmHelper.cs
+++ b/src/Core/ApiClientCodeGen.Core/NpmHelper.cs
@@ -34,6 +34,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core
             catch (Exception e)
             {
                 Logger.Instance.TrackError(e);
+                Logger.Instance.TrackDependencyFailure("npm config get prefix");
                 Trace.TraceError(e.ToString());
                 return null;
             }

--- a/src/VSIX/ApiClientCodeGen.VSIX.Shared/SentryRemoteLogger.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Shared/SentryRemoteLogger.cs
@@ -44,6 +44,11 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient
             SentrySdk.CaptureException(exception);
         }
 
+        public void TrackDependencyFailure(string dependencyName)
+        {
+            // Not implemented
+        }
+
         public void Disable()
         {
             SentrySdk.Close();


### PR DESCRIPTION
The changes here logs dependency failures to application insights using the support key as the anonymous user