### PR TITLE
Track dependency failures and execution performance anonymously

### DIFF
--- a/src/CLI/ApiClientCodeGen.CLI/SentryRemoteLogger.cs
+++ b/src/CLI/ApiClientCodeGen.CLI/SentryRemoteLogger.cs
@@ -44,7 +44,12 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.CLI
             SentrySdk.CaptureException(exception);
         }
 
-        public void TrackDependencyFailure(string dependencyName, string? data = null)
+        public void TrackDependencyFailure(
+            string dependencyName,
+            string? data = null,
+            DateTimeOffset startTime = default,
+            TimeSpan duration = default,
+            bool success = false)
         {
             // Not implemented
         }

--- a/src/CLI/ApiClientCodeGen.CLI/SentryRemoteLogger.cs
+++ b/src/CLI/ApiClientCodeGen.CLI/SentryRemoteLogger.cs
@@ -44,7 +44,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.CLI
             SentrySdk.CaptureException(exception);
         }
 
-        public void TrackDependencyFailure(
+        public void TrackDependency(
             string dependencyName,
             string? data = null,
             DateTimeOffset startTime = default,

--- a/src/Core/ApiClientCodeGen.Core/Generators/AutoRest/AutoRestCSharpCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/AutoRest/AutoRestCSharpCodeGenerator.cs
@@ -114,11 +114,6 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
                     return FileHelper.ReadThenDelete(outputFile);
                 }
             }
-            catch
-            {
-                Logger.Instance.TrackDependency("AutoRest");
-                throw;
-            }
             finally
             {
                 pGenerateProgress?.Progress(90);

--- a/src/Core/ApiClientCodeGen.Core/Generators/AutoRest/AutoRestCSharpCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/AutoRest/AutoRestCSharpCodeGenerator.cs
@@ -77,7 +77,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
                         SwaggerFile,
                         DefaultNamespace);
                     
-                    using var context = new DependencyContext("AutoRest", arguments);
+                    using var context = new DependencyContext("AutoRest", $"{command} {arguments}");
                     processLauncher.Start(command, arguments, Path.GetDirectoryName(SwaggerFile));
                     context.Succeeded();
 
@@ -95,14 +95,14 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
 
                     try
                     {
-                        using var context = new DependencyContext("AutoRest", arguments);
+                        using var context = new DependencyContext("AutoRest", $"{command} {arguments}");
                         processLauncher.Start(command, arguments, Path.GetDirectoryName(SwaggerFile));
                         context.Succeeded();
                     }
                     catch (ProcessLaunchException)
                     {
                         arguments = arguments.Replace("--version=", "--version ");
-                        using var context = new DependencyContext("AutoRest", arguments);
+                        using var context = new DependencyContext("AutoRest", $"{command} {arguments}");
                         processLauncher.Start(command, arguments, Path.GetDirectoryName(SwaggerFile));
                         context.Succeeded();
                     }

--- a/src/Core/ApiClientCodeGen.Core/Generators/AutoRest/AutoRestCSharpCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/AutoRest/AutoRestCSharpCodeGenerator.cs
@@ -116,7 +116,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
             }
             catch
             {
-                Logger.Instance.TrackDependencyFailure("AutoRest");
+                Logger.Instance.TrackDependency("AutoRest");
                 throw;
             }
             finally

--- a/src/Core/ApiClientCodeGen.Core/Generators/AutoRest/AutoRestCSharpCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/AutoRest/AutoRestCSharpCodeGenerator.cs
@@ -114,6 +114,11 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
                     return FileHelper.ReadThenDelete(outputFile);
                 }
             }
+            catch
+            {
+                Logger.Instance.TrackDependency("AutoRest");
+                throw;
+            }
             finally
             {
                 pGenerateProgress?.Progress(90);

--- a/src/Core/ApiClientCodeGen.Core/Generators/NSwag/NSwagCSharpCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/NSwag/NSwagCSharpCodeGenerator.cs
@@ -37,7 +37,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
             }
             catch
             {
-                Logger.Instance.TrackDependencyFailure("NSwag");
+                Logger.Instance.TrackDependency("NSwag");
                 throw;
             }
             finally

--- a/src/Core/ApiClientCodeGen.Core/Generators/NSwag/NSwagCSharpCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/NSwag/NSwagCSharpCodeGenerator.cs
@@ -27,23 +27,26 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
         {
             try
             {
-                pGenerateProgress?.Progress(10);
-                var document = documentFactory.GetDocumentAsync(swaggerFile).GetAwaiter().GetResult();
-                pGenerateProgress?.Progress(20);
-                var settings = generatorSettingsFactory.GetGeneratorSettings(document);
-                pGenerateProgress?.Progress(50);
-                var generator = new CSharpClientGenerator(document, settings);
-                return generator.GenerateFile();
-            }
-            catch
-            {
-                Logger.Instance.TrackDependency("NSwag");
-                throw;
+                using var context = new DependencyContext("NSwag");
+                var code = OnGenerateCode(pGenerateProgress);
+                context.Succeeded();
+                return code;
             }
             finally
             {
                 pGenerateProgress?.Progress(90);
             }
+        }
+
+        private string OnGenerateCode(IProgressReporter? pGenerateProgress)
+        {
+            pGenerateProgress?.Progress(10);
+            var document = documentFactory.GetDocumentAsync(swaggerFile).GetAwaiter().GetResult();
+            pGenerateProgress?.Progress(20);
+            var settings = generatorSettingsFactory.GetGeneratorSettings(document);
+            pGenerateProgress?.Progress(50);
+            var generator = new CSharpClientGenerator(document, settings);
+            return generator.GenerateFile();
         }
     }
 }

--- a/src/Core/ApiClientCodeGen.Core/Generators/NSwag/NSwagCSharpCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/NSwag/NSwagCSharpCodeGenerator.cs
@@ -22,7 +22,6 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
                                             throw new ArgumentNullException(nameof(generatorSettingsFactory));
         }
 
-        [SuppressMessage("Usage", "VSTHRD002:Avoid problematic synchronous waits", Justification = "This is code is called from an old pre-TPL interface")]
         public string GenerateCode(IProgressReporter? pGenerateProgress)
         {
             try
@@ -38,6 +37,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
             }
         }
 
+        [SuppressMessage("Usage", "VSTHRD002:Avoid problematic synchronous waits", Justification = "This is code is called from an old pre-TPL interface")]
         private string OnGenerateCode(IProgressReporter? pGenerateProgress)
         {
             pGenerateProgress?.Progress(10);

--- a/src/Core/ApiClientCodeGen.Core/Generators/NSwag/NSwagCSharpCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/NSwag/NSwagCSharpCodeGenerator.cs
@@ -27,26 +27,23 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
         {
             try
             {
-                using var context = new DependencyContext("NSwag");
-                var code = OnGenerateCode(pGenerateProgress);
-                context.Succeeded();
-                return code;
+                pGenerateProgress?.Progress(10);
+                var document = documentFactory.GetDocumentAsync(swaggerFile).GetAwaiter().GetResult();
+                pGenerateProgress?.Progress(20);
+                var settings = generatorSettingsFactory.GetGeneratorSettings(document);
+                pGenerateProgress?.Progress(50);
+                var generator = new CSharpClientGenerator(document, settings);
+                return generator.GenerateFile();
+            }
+            catch
+            {
+                Logger.Instance.TrackDependency("NSwag");
+                throw;
             }
             finally
             {
                 pGenerateProgress?.Progress(90);
             }
-        }
-
-        private string OnGenerateCode(IProgressReporter? pGenerateProgress)
-        {
-            pGenerateProgress?.Progress(10);
-            var document = documentFactory.GetDocumentAsync(swaggerFile).GetAwaiter().GetResult();
-            pGenerateProgress?.Progress(20);
-            var settings = generatorSettingsFactory.GetGeneratorSettings(document);
-            pGenerateProgress?.Progress(50);
-            var generator = new CSharpClientGenerator(document, settings);
-            return generator.GenerateFile();
         }
     }
 }

--- a/src/Core/ApiClientCodeGen.Core/Generators/NSwagStudio/NSwagStudioCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/NSwagStudio/NSwagStudioCodeGenerator.cs
@@ -46,14 +46,23 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
                 pGenerateProgress?.Progress(50);
 
                 var arguments = $"run \"{nswagStudioFile}\"";
-                processLauncher.Start(command, arguments, Path.GetDirectoryName(nswagStudioFile)!);
+
+                try
+                {
+                    processLauncher.Start(command, arguments, Path.GetDirectoryName(nswagStudioFile)!); 
+                }
+                catch
+                {
+                    Logger.Instance.TrackDependency("NSwag Studio", arguments);
+                    throw;
+                }
             }
             
             pGenerateProgress?.Progress(100);
             return string.Empty;
         }
 
-        private string GetNSwagPath()
+        public string GetNSwagPath()
         {
             var command = options.NSwagPath;
             if (!string.IsNullOrWhiteSpace(command) && File.Exists(command) && !forceDownload)

--- a/src/Core/ApiClientCodeGen.Core/Generators/NSwagStudio/NSwagStudioCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/NSwagStudio/NSwagStudioCodeGenerator.cs
@@ -46,23 +46,14 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
                 pGenerateProgress?.Progress(50);
 
                 var arguments = $"run \"{nswagStudioFile}\"";
-
-                try
-                {
-                    processLauncher.Start(command, arguments, Path.GetDirectoryName(nswagStudioFile)!); 
-                }
-                catch
-                {
-                    Logger.Instance.TrackDependency("NSwag Studio", arguments);
-                    throw;
-                }
+                processLauncher.Start(command, arguments, Path.GetDirectoryName(nswagStudioFile)!);
             }
             
             pGenerateProgress?.Progress(100);
             return string.Empty;
         }
 
-        public string GetNSwagPath()
+        private string GetNSwagPath()
         {
             var command = options.NSwagPath;
             if (!string.IsNullOrWhiteSpace(command) && File.Exists(command) && !forceDownload)

--- a/src/Core/ApiClientCodeGen.Core/Generators/NSwagStudio/NSwagStudioCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/NSwagStudio/NSwagStudioCodeGenerator.cs
@@ -48,7 +48,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
 
                 var arguments = $"run \"{nswagStudioFile}\"";
 
-                using var context = new DependencyContext("NSwag Studio");
+                using var context = new DependencyContext("NSwag Studio", $"{command} {arguments}");
                 processLauncher.Start(command, arguments, Path.GetDirectoryName(nswagStudioFile)!);
                 context.Succeeded();
             }

--- a/src/Core/ApiClientCodeGen.Core/Generators/NSwagStudio/NSwagStudioCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/NSwagStudio/NSwagStudioCodeGenerator.cs
@@ -53,7 +53,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
                 }
                 catch
                 {
-                    Logger.Instance.TrackDependencyFailure("NSwag Studio", arguments);
+                    Logger.Instance.TrackDependency("NSwag Studio", arguments);
                     throw;
                 }
             }

--- a/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiCSharpCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiCSharpCodeGenerator.cs
@@ -103,7 +103,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
             }
             catch
             {
-                Logger.Instance.TrackDependencyFailure("OpenAPI Generator", arguments);
+                Logger.Instance.TrackDependency("OpenAPI Generator", arguments);
                 throw;
             }
             finally

--- a/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiCSharpCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiCSharpCodeGenerator.cs
@@ -91,20 +91,16 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
                     arguments += openApiGeneratorOptions.CustomAdditionalProperties;
                 }
 
-
+                using var context = new DependencyContext("OpenAPI Generator", arguments);
                 processLauncher.Start(
                     javaPathProvider.GetJavaExePath(),
                     arguments,
                     Path.GetDirectoryName(swaggerFile));
+                context.Succeeded();
 
                 pGenerateProgress?.Progress(80);
 
                 return CSharpFileMerger.MergeFilesAndDeleteSource(output);
-            }
-            catch
-            {
-                Logger.Instance.TrackDependency("OpenAPI Generator", arguments);
-                throw;
             }
             finally
             {

--- a/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiCSharpCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiCSharpCodeGenerator.cs
@@ -101,6 +101,11 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
 
                 return CSharpFileMerger.MergeFilesAndDeleteSource(output);
             }
+            catch
+            {
+                Logger.Instance.TrackDependency("OpenAPI Generator", arguments);
+                throw;
+            }
             finally
             {
                 pGenerateProgress?.Progress(90);

--- a/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiCSharpCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiCSharpCodeGenerator.cs
@@ -101,11 +101,6 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
 
                 return CSharpFileMerger.MergeFilesAndDeleteSource(output);
             }
-            catch
-            {
-                Logger.Instance.TrackDependency("OpenAPI Generator", arguments);
-                throw;
-            }
             finally
             {
                 pGenerateProgress?.Progress(90);

--- a/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiCSharpCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiCSharpCodeGenerator.cs
@@ -91,11 +91,9 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
                     arguments += openApiGeneratorOptions.CustomAdditionalProperties;
                 }
 
-                using var context = new DependencyContext("OpenAPI Generator", arguments);
-                processLauncher.Start(
-                    javaPathProvider.GetJavaExePath(),
-                    arguments,
-                    Path.GetDirectoryName(swaggerFile));
+                var java = javaPathProvider.GetJavaExePath();
+                using var context = new DependencyContext("OpenAPI Generator", $"{java} {arguments}");
+                processLauncher.Start(java, arguments, Path.GetDirectoryName(swaggerFile));
                 context.Succeeded();
 
                 pGenerateProgress?.Progress(80);

--- a/src/Core/ApiClientCodeGen.Core/Generators/ProcessLauncher.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/ProcessLauncher.cs
@@ -2,7 +2,6 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
-using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Logging;
 
 namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
 {
@@ -44,8 +43,6 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
             Action<string> onErrorData,
             string? workingDirectory = null)
         {
-            using var context = new DependencyContext(command, arguments);
-            
             Trace.WriteLine("Executing:");
             Trace.WriteLine($"{command} {arguments}");
 
@@ -73,8 +70,6 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
                     onErrorData,
                     workingDirectory);
             }
-            
-            context.Succeeded();
         }
 
         private static void StartWithRetryPolicy(

--- a/src/Core/ApiClientCodeGen.Core/Generators/ProcessLauncher.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/ProcessLauncher.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Logging;
 
 namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
 {
@@ -43,6 +44,8 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
             Action<string> onErrorData,
             string? workingDirectory = null)
         {
+            using var context = new DependencyContext(command, arguments);
+            
             Trace.WriteLine("Executing:");
             Trace.WriteLine($"{command} {arguments}");
 
@@ -70,6 +73,8 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
                     onErrorData,
                     workingDirectory);
             }
+            
+            context.Succeeded();
         }
 
         private static void StartWithRetryPolicy(

--- a/src/Core/ApiClientCodeGen.Core/Generators/Swagger/SwaggerCSharpCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/Swagger/SwaggerCSharpCodeGenerator.cs
@@ -67,6 +67,11 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
 
                 return CSharpFileMerger.MergeFilesAndDeleteSource(output);
             }
+            catch
+            {
+                Logger.Instance.TrackDependency("Swagger Codegen CLI", arguments);
+                throw;
+            }
             finally
             {
                 pGenerateProgress?.Progress(90);

--- a/src/Core/ApiClientCodeGen.Core/Generators/Swagger/SwaggerCSharpCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/Swagger/SwaggerCSharpCodeGenerator.cs
@@ -62,15 +62,13 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
                             "-DapiTests=false -DmodelTests=false " +
                             $"-DpackageName={defaultNamespace} ";
 
+                using var context = new DependencyContext("Swagger Codegen CLI", arguments);
                 processLauncher.Start(javaPathProvider.GetJavaExePath(), arguments);
+                context.Succeeded();
+                
                 pGenerateProgress?.Progress(80);
 
                 return CSharpFileMerger.MergeFilesAndDeleteSource(output);
-            }
-            catch
-            {
-                Logger.Instance.TrackDependency("Swagger Codegen CLI", arguments);
-                throw;
             }
             finally
             {

--- a/src/Core/ApiClientCodeGen.Core/Generators/Swagger/SwaggerCSharpCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/Swagger/SwaggerCSharpCodeGenerator.cs
@@ -67,11 +67,6 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
 
                 return CSharpFileMerger.MergeFilesAndDeleteSource(output);
             }
-            catch
-            {
-                Logger.Instance.TrackDependency("Swagger Codegen CLI", arguments);
-                throw;
-            }
             finally
             {
                 pGenerateProgress?.Progress(90);

--- a/src/Core/ApiClientCodeGen.Core/Generators/Swagger/SwaggerCSharpCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/Swagger/SwaggerCSharpCodeGenerator.cs
@@ -69,7 +69,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
             }
             catch
             {
-                Logger.Instance.TrackDependencyFailure("Swagger Codegen CLI", arguments);
+                Logger.Instance.TrackDependency("Swagger Codegen CLI", arguments);
                 throw;
             }
             finally

--- a/src/Core/ApiClientCodeGen.Core/Generators/Swagger/SwaggerCSharpCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/Swagger/SwaggerCSharpCodeGenerator.cs
@@ -62,8 +62,9 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators
                             "-DapiTests=false -DmodelTests=false " +
                             $"-DpackageName={defaultNamespace} ";
 
-                using var context = new DependencyContext("Swagger Codegen CLI", arguments);
-                processLauncher.Start(javaPathProvider.GetJavaExePath(), arguments);
+                var java = javaPathProvider.GetJavaExePath();
+                using var context = new DependencyContext("Swagger Codegen CLI", $"{java} {arguments}");
+                processLauncher.Start(java, arguments);
                 context.Succeeded();
                 
                 pGenerateProgress?.Progress(80);

--- a/src/Core/ApiClientCodeGen.Core/Installer/NpmInstaller.cs
+++ b/src/Core/ApiClientCodeGen.Core/Installer/NpmInstaller.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators;
+using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Logging;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.General;
 
 namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer
@@ -18,9 +19,19 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer
         {
             Trace.WriteLine($"Attempting to install {packageName} through NPM");
 
-            processLauncher.Start(PathProvider.GetNpmPath(), $"install -g {packageName}");
+            try
+            {
+                processLauncher.Start(
+                    PathProvider.GetNpmPath(),
+                    $"install -g {packageName}");
 
-            Trace.WriteLine($"{packageName} installed successfully through NPM");
+                Trace.WriteLine($"{packageName} installed successfully through NPM");
+            }
+            catch
+            {
+                Logger.Instance.TrackDependency("npm", $"install -g {packageName}");
+                throw;
+            }
         }
     }
 }

--- a/src/Core/ApiClientCodeGen.Core/Installer/NpmInstaller.cs
+++ b/src/Core/ApiClientCodeGen.Core/Installer/NpmInstaller.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Diagnostics;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Generators;
-using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Logging;
 using ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Options.General;
 
 namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer
@@ -19,19 +18,9 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer
         {
             Trace.WriteLine($"Attempting to install {packageName} through NPM");
 
-            try
-            {
-                processLauncher.Start(
-                    PathProvider.GetNpmPath(),
-                    $"install -g {packageName}");
+            processLauncher.Start(PathProvider.GetNpmPath(), $"install -g {packageName}");
 
-                Trace.WriteLine($"{packageName} installed successfully through NPM");
-            }
-            catch
-            {
-                Logger.Instance.TrackDependency("npm", $"install -g {packageName}");
-                throw;
-            }
+            Trace.WriteLine($"{packageName} installed successfully through NPM");
         }
     }
 }

--- a/src/Core/ApiClientCodeGen.Core/Installer/NpmInstaller.cs
+++ b/src/Core/ApiClientCodeGen.Core/Installer/NpmInstaller.cs
@@ -19,19 +19,11 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer
         {
             Trace.WriteLine($"Attempting to install {packageName} through NPM");
 
-            try
-            {
-                processLauncher.Start(
-                    PathProvider.GetNpmPath(),
-                    $"install -g {packageName}");
+            using var context = new DependencyContext($"npm install -g {packageName}");
+            processLauncher.Start(PathProvider.GetNpmPath(), $"install -g {packageName}");
+            context.Succeeded();
 
-                Trace.WriteLine($"{packageName} installed successfully through NPM");
-            }
-            catch
-            {
-                Logger.Instance.TrackDependency("npm", $"install -g {packageName}");
-                throw;
-            }
+            Trace.WriteLine($"{packageName} installed successfully through NPM");
         }
     }
 }

--- a/src/Core/ApiClientCodeGen.Core/Installer/NpmInstaller.cs
+++ b/src/Core/ApiClientCodeGen.Core/Installer/NpmInstaller.cs
@@ -29,7 +29,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer
             }
             catch
             {
-                Logger.Instance.TrackDependencyFailure("npm", $"install -g {packageName}");
+                Logger.Instance.TrackDependency("npm", $"install -g {packageName}");
                 throw;
             }
         }

--- a/src/Core/ApiClientCodeGen.Core/Installer/WebDownloader.cs
+++ b/src/Core/ApiClientCodeGen.Core/Installer/WebDownloader.cs
@@ -13,6 +13,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer
         {
             try
             {
+                using var context = new DependencyContext($"GET {address}");
                 using var mutex = new Mutex(false, nameof(WebDownloader));
                 if (!mutex.WaitOne(TimeSpan.FromMinutes(2)))
                     throw new TimeoutException();
@@ -21,11 +22,12 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer
                 client.DownloadFile(address, filename);
             
                 mutex.ReleaseMutex();
+                context.Succeeded();
             }
             catch (Exception e)
             {
                 Logger.Instance.TrackError(e);
-                Logger.Instance.TrackDependency($"GET {address}");
+                throw;
             }
         }
     }

--- a/src/Core/ApiClientCodeGen.Core/Installer/WebDownloader.cs
+++ b/src/Core/ApiClientCodeGen.Core/Installer/WebDownloader.cs
@@ -25,7 +25,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer
             catch (Exception e)
             {
                 Logger.Instance.TrackError(e);
-                Logger.Instance.TrackDependencyFailure($"GET {address}");
+                Logger.Instance.TrackDependency($"GET {address}");
             }
         }
     }

--- a/src/Core/ApiClientCodeGen.Core/Installer/WebDownloader.cs
+++ b/src/Core/ApiClientCodeGen.Core/Installer/WebDownloader.cs
@@ -13,7 +13,6 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer
         {
             try
             {
-                using var context = new DependencyContext($"GET {address}");
                 using var mutex = new Mutex(false, nameof(WebDownloader));
                 if (!mutex.WaitOne(TimeSpan.FromMinutes(2)))
                     throw new TimeoutException();
@@ -22,12 +21,11 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Installer
                 client.DownloadFile(address, filename);
             
                 mutex.ReleaseMutex();
-                context.Succeeded();
             }
             catch (Exception e)
             {
                 Logger.Instance.TrackError(e);
-                throw;
+                Logger.Instance.TrackDependency($"GET {address}");
             }
         }
     }

--- a/src/Core/ApiClientCodeGen.Core/Logging/AppInsightsRemoteLogger.cs
+++ b/src/Core/ApiClientCodeGen.Core/Logging/AppInsightsRemoteLogger.cs
@@ -43,7 +43,12 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Logging
             telemetryClient.Flush();
         }
 
-        public void TrackDependencyFailure(string dependencyName, string? data = null)
+        public void TrackDependencyFailure(
+            string dependencyName,
+            string? data = null,
+            DateTimeOffset startTime = default,
+            TimeSpan duration = default,
+            bool success = false)
         {
             if (TestingUtility.IsRunningFromUnitTest || Debugger.IsAttached)
                 return;
@@ -51,8 +56,10 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Logging
                 new DependencyTelemetry
                 {
                     Name = dependencyName,
-                    Success = false,
-                    Data = data
+                    Success = success,
+                    Data = data,
+                    Timestamp = startTime == default ? DateTimeOffset.UtcNow : startTime,
+                    Duration = duration == default ? TimeSpan.Zero : duration 
                 });
             telemetryClient.Flush();
         }

--- a/src/Core/ApiClientCodeGen.Core/Logging/AppInsightsRemoteLogger.cs
+++ b/src/Core/ApiClientCodeGen.Core/Logging/AppInsightsRemoteLogger.cs
@@ -43,7 +43,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Logging
             telemetryClient.Flush();
         }
 
-        public void TrackDependencyFailure(
+        public void TrackDependency(
             string dependencyName,
             string? data = null,
             DateTimeOffset startTime = default,

--- a/src/Core/ApiClientCodeGen.Core/Logging/DependencyContext.cs
+++ b/src/Core/ApiClientCodeGen.Core/Logging/DependencyContext.cs
@@ -11,10 +11,11 @@ public sealed class DependencyContext : IDisposable
     private readonly DateTimeOffset timestamp;
     private bool success;
 
-    public DependencyContext(string dependencyName, string? data = null)
+    public DependencyContext(string dependencyName, string? data = null, bool success = false)
     {
         this.dependencyName = dependencyName;
         this.data = data;
+        this.success = success;
         timestamp = DateTimeOffset.UtcNow;
         stopwatch = Stopwatch.StartNew();
     }

--- a/src/Core/ApiClientCodeGen.Core/Logging/DependencyContext.cs
+++ b/src/Core/ApiClientCodeGen.Core/Logging/DependencyContext.cs
@@ -1,48 +1,49 @@
 ﻿using System;
 using System.Diagnostics;
 
-namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Logging;
-
-public sealed class DependencyContext : IDisposable
+namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Logging
 {
-    private readonly string dependencyName;
-    private readonly string? data;
-    private readonly Stopwatch stopwatch;
-    private readonly DateTimeOffset timestamp;
-    private bool success;
-
-    public DependencyContext(string dependencyName, string? data = null, bool success = false)
+    public sealed class DependencyContext : IDisposable
     {
-        this.dependencyName = dependencyName;
-        this.data = data;
-        this.success = success;
-        timestamp = DateTimeOffset.UtcNow;
-        stopwatch = Stopwatch.StartNew();
-    }
+        private readonly string dependencyName;
+        private readonly string? data;
+        private readonly Stopwatch stopwatch;
+        private readonly DateTimeOffset timestamp;
+        private bool success;
 
-    public void Succeeded() => success = true;
-
-    public void Dispose()
-    {
-        Dispose(true);
-        GC.SuppressFinalize(this);
-    }
-
-    ~DependencyContext()
-    {
-        Dispose(false);
-    }
-
-    private void Dispose(bool disposing)
-    {
-        if (disposing)
+        public DependencyContext(string dependencyName, string? data = null, bool success = false)
         {
-            Logger.Instance.TrackDependency(
-                dependencyName,
-                data,
-                timestamp,
-                stopwatch.Elapsed,
-                success);
+            this.dependencyName = dependencyName;
+            this.data = data;
+            this.success = success;
+            timestamp = DateTimeOffset.UtcNow;
+            stopwatch = Stopwatch.StartNew();
+        }
+
+        public void Succeeded() => success = true;
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        ~DependencyContext()
+        {
+            Dispose(false);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                Logger.Instance.TrackDependency(
+                    dependencyName,
+                    data,
+                    timestamp,
+                    stopwatch.Elapsed,
+                    success);
+            }
         }
     }
 }

--- a/src/Core/ApiClientCodeGen.Core/Logging/DependencyContext.cs
+++ b/src/Core/ApiClientCodeGen.Core/Logging/DependencyContext.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Logging;
+
+public sealed class DependencyContext : IDisposable
+{
+    private readonly string dependencyName;
+    private readonly string? data;
+    private readonly Stopwatch stopwatch;
+    private readonly DateTimeOffset timestamp;
+    private bool success;
+
+    public DependencyContext(string dependencyName, string? data = null)
+    {
+        this.dependencyName = dependencyName;
+        this.data = data;
+        timestamp = DateTimeOffset.UtcNow;
+        stopwatch = Stopwatch.StartNew();
+    }
+
+    public void Succeeded() => success = true;
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    ~DependencyContext()
+    {
+        Dispose(false);
+    }
+
+    private void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            Logger.Instance.TrackDependency(
+                dependencyName,
+                data,
+                timestamp,
+                stopwatch.Elapsed,
+                success);
+        }
+    }
+}

--- a/src/Core/ApiClientCodeGen.Core/Logging/ExceptionlessRemoteLogger.cs
+++ b/src/Core/ApiClientCodeGen.Core/Logging/ExceptionlessRemoteLogger.cs
@@ -66,7 +66,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Logging
             exception.ToExceptionless().Submit();
         }
 
-        public void TrackDependencyFailure(
+        public void TrackDependency(
             string dependencyName,
             string? data = null,
             DateTimeOffset startTime = default,

--- a/src/Core/ApiClientCodeGen.Core/Logging/ExceptionlessRemoteLogger.cs
+++ b/src/Core/ApiClientCodeGen.Core/Logging/ExceptionlessRemoteLogger.cs
@@ -66,7 +66,12 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Logging
             exception.ToExceptionless().Submit();
         }
 
-        public void TrackDependencyFailure(string dependencyName, string? data = null)
+        public void TrackDependencyFailure(
+            string dependencyName,
+            string? data = null,
+            DateTimeOffset startTime = default,
+            TimeSpan duration = default,
+            bool success = false)
         {
             // Not implemented
         }

--- a/src/Core/ApiClientCodeGen.Core/Logging/IRemoteLogger.cs
+++ b/src/Core/ApiClientCodeGen.Core/Logging/IRemoteLogger.cs
@@ -7,7 +7,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Logging
         void TrackFeatureUsage(string featureName, params string[] tags);
         void TrackError(Exception exception);
 
-        void TrackDependencyFailure(
+        void TrackDependency(
             string dependencyName,
             string? data = null,
             DateTimeOffset startTime = default,

--- a/src/Core/ApiClientCodeGen.Core/Logging/IRemoteLogger.cs
+++ b/src/Core/ApiClientCodeGen.Core/Logging/IRemoteLogger.cs
@@ -6,7 +6,14 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Logging
     {
         void TrackFeatureUsage(string featureName, params string[] tags);
         void TrackError(Exception exception);
-        void TrackDependencyFailure(string dependencyName, string? data = null);
+
+        void TrackDependencyFailure(
+            string dependencyName,
+            string? data = null,
+            DateTimeOffset startTime = default,
+            TimeSpan duration = default,
+            bool success = false);
+
         void Disable();
     }
 }

--- a/src/Core/ApiClientCodeGen.Core/Logging/RemoteLogger.cs
+++ b/src/Core/ApiClientCodeGen.Core/Logging/RemoteLogger.cs
@@ -37,7 +37,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Logging
                 logger.TrackError(exception);
         }
 
-        public void TrackDependencyFailure(
+        public void TrackDependency(
             string dependencyName,
             string? data = null,
             DateTimeOffset startTime = default,
@@ -45,7 +45,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Logging
             bool success = false)
         {
             foreach (var logger in Loggers)
-                logger.TrackDependencyFailure(
+                logger.TrackDependency(
                     dependencyName,
                     data,
                     startTime,

--- a/src/Core/ApiClientCodeGen.Core/Logging/RemoteLogger.cs
+++ b/src/Core/ApiClientCodeGen.Core/Logging/RemoteLogger.cs
@@ -37,13 +37,23 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core.Logging
                 logger.TrackError(exception);
         }
 
-        public void TrackDependencyFailure(string dependencyName, string? data = null)
+        public void TrackDependencyFailure(
+            string dependencyName,
+            string? data = null,
+            DateTimeOffset startTime = default,
+            TimeSpan duration = default,
+            bool success = false)
         {
             foreach (var logger in Loggers)
-                logger.TrackDependencyFailure(dependencyName, data);
+                logger.TrackDependencyFailure(
+                    dependencyName,
+                    data,
+                    startTime,
+                    duration,
+                    success);
         }
 
-        public void Disable() 
-            => Loggers.ForEach(c=>c.Disable());
+        public void Disable()
+            => Loggers.ForEach(c => c.Disable());
     }
 }

--- a/src/Core/ApiClientCodeGen.Core/NpmHelper.cs
+++ b/src/Core/ApiClientCodeGen.Core/NpmHelper.cs
@@ -34,7 +34,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core
             catch (Exception e)
             {
                 Logger.Instance.TrackError(e);
-                Logger.Instance.TrackDependencyFailure("npm", "config get prefix");
+                Logger.Instance.TrackDependency("npm", "config get prefix");
                 Trace.TraceError(e.ToString());
                 return null;
             }

--- a/src/Core/ApiClientCodeGen.Core/NpmHelper.cs
+++ b/src/Core/ApiClientCodeGen.Core/NpmHelper.cs
@@ -24,17 +24,19 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core
             {
                 var npm = GetNpmPath();
                 string prefix = null!;
+
+                using var context = new DependencyContext("npm config get prefix");
                 (processLauncher ?? new ProcessLauncher()).Start(
                     npm,
                     "config get prefix",
                     o => prefix += o,
                     e => Trace.WriteLine(e));
+                context.Succeeded();
                 return prefix;
             }
             catch (Exception e)
             {
                 Logger.Instance.TrackError(e);
-                Logger.Instance.TrackDependency("npm", "config get prefix");
                 Trace.TraceError(e.ToString());
                 return null;
             }

--- a/src/Core/ApiClientCodeGen.Core/NpmHelper.cs
+++ b/src/Core/ApiClientCodeGen.Core/NpmHelper.cs
@@ -34,6 +34,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core
             catch (Exception e)
             {
                 Logger.Instance.TrackError(e);
+                Logger.Instance.TrackDependency("npm", "config get prefix");
                 Trace.TraceError(e.ToString());
                 return null;
             }

--- a/src/Core/ApiClientCodeGen.Core/NpmHelper.cs
+++ b/src/Core/ApiClientCodeGen.Core/NpmHelper.cs
@@ -34,7 +34,6 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient.Core
             catch (Exception e)
             {
                 Logger.Instance.TrackError(e);
-                Logger.Instance.TrackDependency("npm", "config get prefix");
                 Trace.TraceError(e.ToString());
                 return null;
             }

--- a/src/VSIX/ApiClientCodeGen.VSIX.Shared/SentryRemoteLogger.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Shared/SentryRemoteLogger.cs
@@ -44,7 +44,7 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient
             SentrySdk.CaptureException(exception);
         }
 
-        public void TrackDependencyFailure(
+        public void TrackDependency(
             string dependencyName,
             string? data = null,
             DateTimeOffset startTime = default,

--- a/src/VSIX/ApiClientCodeGen.VSIX.Shared/SentryRemoteLogger.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Shared/SentryRemoteLogger.cs
@@ -44,12 +44,12 @@ namespace ChristianHelle.DeveloperTools.CodeGenerators.ApiClient
             SentrySdk.CaptureException(exception);
         }
 
-        public void TrackDependencyFailure(string dependencyName, string? data = null)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void TrackDependencyFailure(string dependencyName)
+        public void TrackDependencyFailure(
+            string dependencyName,
+            string? data = null,
+            DateTimeOffset startTime = default,
+            TimeSpan duration = default,
+            bool success = false)
         {
             // Not implemented
         }

--- a/src/VSMac/ApiClientCodeGen.VSMac/SentryRemoteLogger.cs
+++ b/src/VSMac/ApiClientCodeGen.VSMac/SentryRemoteLogger.cs
@@ -32,7 +32,12 @@ namespace ApiClientCodeGen.VSMac
             SentrySdk.CaptureException(exception);
         }
 
-        public void TrackDependencyFailure(string dependencyName, string? data = null)
+        public void TrackDependencyFailure(
+            string dependencyName,
+            string? data = null,
+            DateTimeOffset startTime = default,
+            TimeSpan duration = default,
+            bool success = false)
         {
             // Not implemented
         }

--- a/src/VSMac/ApiClientCodeGen.VSMac/SentryRemoteLogger.cs
+++ b/src/VSMac/ApiClientCodeGen.VSMac/SentryRemoteLogger.cs
@@ -32,7 +32,7 @@ namespace ApiClientCodeGen.VSMac
             SentrySdk.CaptureException(exception);
         }
 
-        public void TrackDependencyFailure(
+        public void TrackDependency(
             string dependencyName,
             string? data = null,
             DateTimeOffset startTime = default,


### PR DESCRIPTION
The changes here track the dependency execution time and failures for the following dependencies:
- NPM
- Java
- NSwag
- NSwagStudio
- OpenAPI Generator
- AutoRest
- Swagger Codegen CLI
- HTTP downloads