### PR TITLE
Remove Visual Studio 2017 support

### DIFF
--- a/.github/workflows/cli-tool.yml
+++ b/.github/workflows/cli-tool.yml
@@ -18,7 +18,7 @@ on:
     - cron:  '0 8 * * *'
 
 env:
-  VERSION: 1.5.0.${{ github.run_number }}
+  VERSION: 1.6.0.${{ github.run_number }}
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
       - 'release'
 
 env:
-  VERSION: 1.5.${{ github.run_number }}
+  VERSION: 1.6.${{ github.run_number }}
   NUGET_REPO_URL: 'https://api.nuget.org/v3/index.json'
 
 jobs:

--- a/.github/workflows/vsix.yml
+++ b/.github/workflows/vsix.yml
@@ -17,7 +17,7 @@ on:
     - cron:  '0 8 * * *'
 
 env:
-  VERSION: 1.5.0.${{ github.run_number }}
+  VERSION: 1.6.0.${{ github.run_number }}
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ A collection of Visual Studio C# custom tool code generators for Swagger / OpenA
 #### Download
 
 - **[Visual Studio 2022](https://marketplace.visualstudio.com/items?itemName=ChristianResmaHelle.ApiClientCodeGenerator2022)**
-- **[Visual Studio 2017 and 2019](https://marketplace.visualstudio.com/items?itemName=ChristianResmaHelle.ApiClientCodeGenerator)**
+- **[Visual Studio 2019 ~~and 2017~~](https://marketplace.visualstudio.com/items?itemName=ChristianResmaHelle.ApiClientCodeGenerator)**
 - **[Visual Studio for Mac](https://github.com/christianhelle/apiclientcodegen/releases/latest)**. Follow **[these instructions](#visual-studio-for-mac-1)** for update convenience on Visual Studio for Mac
 
 ## Features
 
-- Supports Visual Studio 2017, 2019, 2022, and [Visual Studio for Mac](#visual-studio-for-mac-1)
+- Supports Visual Studio ~~2017,~~ 2019, 2022, and [Visual Studio for Mac](#visual-studio-for-mac-1)
 - Add New REST API Client to a project from an OpenAPI specification URL (e.g https://petstore.swagger.io/v2/swagger.json) using [AutoRest](https://github.com/Azure/autorest), [NSwag](https://github.com/RicoSuter/NSwag), [Swagger Codegen](https://github.com/swagger-api/swagger-codegen), or [OpenAPI Generator](https://github.com/OpenAPITools/openapi-generator)
 - Define custom namespace for the generated file
 - Auto-updating of generated code file when changes are made to the OpenAPI specification JSON or YAML file

--- a/docs/Marketplace.md
+++ b/docs/Marketplace.md
@@ -8,7 +8,7 @@ A collection of Visual Studio C# custom tool code generators for Swagger / OpenA
 
 ## Features
 
-- Supports Visual Studio 2017 and 2019
+- Supports Visual Studio 2019
 - Add New REST API Client to a project from an OpenAPI specification URL (e.g https://petstore.swagger.io/v2/swagger.json) using [AutoRest](https://github.com/Azure/autorest), [NSwag](https://github.com/RicoSuter/NSwag), [Swagger Codegen](https://github.com/swagger-api/swagger-codegen), or [OpenAPI Generator](https://github.com/OpenAPITools/openapi-generator)
 - Define custom namespace for the generated file
 - Auto-updating of generated code file when changes are made to the OpenAPI specification JSON or YAML file

--- a/src/VSIX/ApiClientCodeGen.VSIX/source.extension.vsixmanifest
+++ b/src/VSIX/ApiClientCodeGen.VSIX/source.extension.vsixmanifest
@@ -11,7 +11,7 @@
         <Tags>OpenAPI; Swagger; NSwag; AutoRest; REST API; Code Generator</Tags>
     </Metadata>
     <Installation>
-      <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0, 17.0)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0)" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.7.2)" />


### PR DESCRIPTION
I decided to remove support for Visual Studio 2017 as this product is now 5 years old and is preventing moving forward to newer dependencies. Visual Studio 2017 has an internal hard dependency on Newtonsoft.Json v9.0 but NSwag has now bumped their minimal Newtonsoft.Json version to v10.0.1. 

It's time to move on...