### PR TITLE
Fix Visual Studio 2022 crash when used in MAUI projects

### DIFF
--- a/src/VSIX/ApiClientCodeGen.VSIX.Shared/VsPackage.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Shared/VsPackage.cs
@@ -13,10 +13,11 @@ using Rapicgen.Options.General;
 using Rapicgen.Options.NSwag;
 using Rapicgen.Options.NSwagStudio;
 using Rapicgen.Options.OpenApiGenerator;
-using Rapicgen.Windows;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Task = System.Threading.Tasks.Task;
+using Rapicgen.Windows;
+using System.Diagnostics;
 
 namespace Rapicgen
 {
@@ -30,8 +31,8 @@ namespace Rapicgen
         CustomToolSetterCommand.ContextGuid,
         CustomToolSetterCommand.Name,
         CustomToolSetterCommand.Expression,
-        new [] { CustomToolSetterCommand.TermNameJson, CustomToolSetterCommand.TermNameYaml },
-        new [] { CustomToolSetterCommand.TermValueJson, CustomToolSetterCommand.TermValueYaml })]
+        new[] { CustomToolSetterCommand.TermNameJson, CustomToolSetterCommand.TermNameYaml },
+        new[] { CustomToolSetterCommand.TermValueJson, CustomToolSetterCommand.TermValueYaml })]
     [ProvideUIContextRule(
         NSwagStudioCommand.ContextGuid,
         NSwagStudioCommand.Name,
@@ -103,10 +104,11 @@ namespace Rapicgen
             CancellationToken cancellationToken,
             IProgress<ServiceProgressData> progress)
         {
+            Trace.Listeners.Add(new OutputWindowTraceListener());
             Logger.Setup(new SentryRemoteLogger()).WithDefaultTags("VSIX");
+
             await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
             await base.InitializeAsync(cancellationToken, progress);
-            OutputWindow.Initialize(this, VsixName);
             Instance = this;
 
             foreach (var command in commands)

--- a/src/VSIX/ApiClientCodeGen.VSIX.Shared/Windows/OutputWindow.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Shared/Windows/OutputWindow.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft;
 using Microsoft.VisualStudio.Shell;
@@ -25,15 +24,15 @@ namespace Rapicgen.Windows
             output = (IVsOutputWindow)provider.GetService(typeof(SVsOutputWindow));
             Assumes.Present(output);
             name = outputSource;
-
-            Trace.Listeners.Add(new OutputWindowTraceListener());
         }
-        
+
         public static void Log(object message)
         {
             try
             {
-                if (EnsurePane()) 
+                Initialize(VsPackage.Instance, VsPackage.VsixName);
+
+                if (EnsurePane())
                     pane?.OutputStringThreadSafe($"{DateTime.Now}: {message}{Environment.NewLine}");
             }
             catch
@@ -41,7 +40,7 @@ namespace Rapicgen.Windows
                 // ignored
             }
         }
-        
+
         private static bool EnsurePane()
         {
             if (pane != null)


### PR DESCRIPTION
This resolves #449 