### PR TITLE
Upgrade Rapicgen CLI Tool to target .NET 6.0

### DIFF
--- a/.github/workflows/cli-tool.yml
+++ b/.github/workflows/cli-tool.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Package
       run: |
         dotnet pack --no-build -c Release /p:UseSourceLink=true src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -p:PackageVersion="${{ env.VERSION }}"
-        nuget pack src/Core/ApiClientCodeGen.Core/ApiClientCodeGen.Core.csproj -Version="${{ env.VERSION }}"
+        nuget pack src/Core/ApiClientCodeGen.Core/ApiClientCodeGen.Core.csproj -Version ${{ env.VERSION }} -Properties Configuration=Release
 
     - name: Publish artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/cli-tool.yml
+++ b/.github/workflows/cli-tool.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Package
       run: |
         dotnet pack --no-build -c Release /p:UseSourceLink=true src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -p:PackageVersion="${{ env.VERSION }}"
-        dotnet pack --no-build -c Release /p:UseSourceLink=true src/Core/ApiClientCodeGen.Core/ApiClientCodeGen.Core.csproj -p:PackageVersion="${{ env.VERSION }}"
+        nuget pack /p:UseSourceLink=true src/Core/ApiClientCodeGen.Core/ApiClientCodeGen.Core.csproj -p:PackageVersion="${{ env.VERSION }}"
 
     - name: Publish artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/cli-tool.yml
+++ b/.github/workflows/cli-tool.yml
@@ -47,7 +47,9 @@ jobs:
       continue-on-error: true
 
     - name: Package
-      run: dotnet pack --no-build -c Release /p:UseSourceLink=true src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -p:PackageVersion="${{ env.VERSION }}"
+      run: |
+        dotnet pack --no-build -c Release /p:UseSourceLink=true src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -p:PackageVersion="${{ env.VERSION }}"
+        dotnet pack --no-build -c Release /p:UseSourceLink=true src/Core/ApiClientCodeGen.Core/ApiClientCodeGen.Core.csproj -p:PackageVersion="${{ env.VERSION }}"
 
     - name: Publish artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/cli-tool.yml
+++ b/.github/workflows/cli-tool.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Package
       run: |
         dotnet pack --no-build -c Release /p:UseSourceLink=true src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -p:PackageVersion="${{ env.VERSION }}"
-        nuget pack /p:UseSourceLink=true src/Core/ApiClientCodeGen.Core/ApiClientCodeGen.Core.csproj -p:PackageVersion="${{ env.VERSION }}"
+        nuget pack src/Core/ApiClientCodeGen.Core/ApiClientCodeGen.Core.csproj -p:PackageVersion="${{ env.VERSION }}"
 
     - name: Publish artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/cli-tool.yml
+++ b/.github/workflows/cli-tool.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Package
       run: |
         dotnet pack --no-build -c Release /p:UseSourceLink=true src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -p:PackageVersion="${{ env.VERSION }}"
-        nuget pack src/Core/ApiClientCodeGen.Core/ApiClientCodeGen.Core.csproj -p:PackageVersion="${{ env.VERSION }}"
+        nuget pack src/Core/ApiClientCodeGen.Core/ApiClientCodeGen.Core.csproj -Version="${{ env.VERSION }}"
 
     - name: Publish artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
     - name: Package CLI Tool
       run: dotnet pack --no-build -c Release /p:UseSourceLink=true src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -p:PackageVersion="${{ env.VERSION }}"
     - name: Package Rapicgen Core
-      run: nuget pack src/Core/ApiClientCodeGen.Core/ApiClientCodeGen.Core.csproj -Version="${{ env.VERSION }}"
+      run: nuget pack src/Core/ApiClientCodeGen.Core/ApiClientCodeGen.Core.csproj -Version ${{ env.VERSION }} -Properties Configuration=Release
     - name: Push packages to NuGet
       run: dotnet nuget push **/*.nupkg -k ${{ secrets.NUGET_KEY }} -s ${{ env.NUGET_REPO_URL }} --no-symbols true
       continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
     - name: Package CLI Tool
       run: dotnet pack --no-build -c Release /p:UseSourceLink=true src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -p:PackageVersion="${{ env.VERSION }}"
     - name: Package Rapicgen Core
-      run: dotnet pack --no-build -c Release /p:UseSourceLink=true src/Core/ApiClientCodeGen.Core/ApiClientCodeGen.Core.csproj -p:PackageVersion="${{ env.VERSION }}"
+      run: nuget pack /p:UseSourceLink=true src/Core/ApiClientCodeGen.Core/ApiClientCodeGen.Core.csproj -p:PackageVersion="${{ env.VERSION }}"
     - name: Push packages to NuGet
       run: dotnet nuget push **/*.nupkg -k ${{ secrets.NUGET_KEY }} -s ${{ env.NUGET_REPO_URL }} --no-symbols true
       continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
     - name: Package CLI Tool
       run: dotnet pack --no-build -c Release /p:UseSourceLink=true src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -p:PackageVersion="${{ env.VERSION }}"
     - name: Package Rapicgen Core
-      run: nuget pack src/Core/ApiClientCodeGen.Core/ApiClientCodeGen.Core.csproj -p:PackageVersion="${{ env.VERSION }}"
+      run: nuget pack src/Core/ApiClientCodeGen.Core/ApiClientCodeGen.Core.csproj -Version="${{ env.VERSION }}"
     - name: Push packages to NuGet
       run: dotnet nuget push **/*.nupkg -k ${{ secrets.NUGET_KEY }} -s ${{ env.NUGET_REPO_URL }} --no-symbols true
       continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
     - name: Package CLI Tool
       run: dotnet pack --no-build -c Release /p:UseSourceLink=true src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -p:PackageVersion="${{ env.VERSION }}"
     - name: Package Rapicgen Core
-      run: nuget pack /p:UseSourceLink=true src/Core/ApiClientCodeGen.Core/ApiClientCodeGen.Core.csproj -p:PackageVersion="${{ env.VERSION }}"
+      run: nuget pack src/Core/ApiClientCodeGen.Core/ApiClientCodeGen.Core.csproj -p:PackageVersion="${{ env.VERSION }}"
     - name: Push packages to NuGet
       run: dotnet nuget push **/*.nupkg -k ${{ secrets.NUGET_KEY }} -s ${{ env.NUGET_REPO_URL }} --no-symbols true
       continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,8 +70,10 @@ jobs:
       working-directory: src
     - name: Build
       run: dotnet build -c Release /p:UseSourceLink=true src/Rapicgen.sln -p:PackageVersion="${{ env.VERSION }}"
-    - name: Package
+    - name: Package CLI Tool
       run: dotnet pack --no-build -c Release /p:UseSourceLink=true src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -p:PackageVersion="${{ env.VERSION }}"
+    - name: Package Rapicgen Core
+      run: dotnet pack --no-build -c Release /p:UseSourceLink=true src/Core/ApiClientCodeGen.Core/ApiClientCodeGen.Core.csproj -p:PackageVersion="${{ env.VERSION }}"
     - name: Push packages to NuGet
       run: dotnet nuget push **/*.nupkg -k ${{ secrets.NUGET_KEY }} -s ${{ env.NUGET_REPO_URL }} --no-symbols true
       continue-on-error: true

--- a/.github/workflows/sonar-cloud.yml
+++ b/.github/workflows/sonar-cloud.yml
@@ -6,7 +6,6 @@ on:
       - '**/*'
       - '!.github/workflows/sonar-cloud.yml'
       - '!src/build.cake'
-      - '!src/**/*.csproj'
       - '!src/**/*.cs'
     branches: 
     - '*'

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -51,10 +51,10 @@ jobs:
       working-directory: src
 
     - name: Core test project
-      run: dotnet test src/Core/ApiClientCodeGen.Core.Tests\ApiClientCodeGen.Core.Tests.csproj -f netcoreapp3.1
+      run: dotnet test src/Core/ApiClientCodeGen.Core.Tests\ApiClientCodeGen.Core.Tests.csproj -f net6.0
 
     - name: Core Integration Test project
-      run: dotnet test src/Core/ApiClientCodeGen.Core.IntegrationTests\ApiClientCodeGen.Core.IntegrationTests.csproj -f netcoreapp3.1
+      run: dotnet test src/Core/ApiClientCodeGen.Core.IntegrationTests\ApiClientCodeGen.Core.IntegrationTests.csproj -f net6.0
 
   vsmac:
 
@@ -71,10 +71,10 @@ jobs:
         dotnet-version: 3.1
 
     - name: Core Test project
-      run: dotnet test src/Core/ApiClientCodeGen.Core.Tests/ApiClientCodeGen.Core.Tests.csproj -f netcoreapp3.1
+      run: dotnet test src/Core/ApiClientCodeGen.Core.Tests/ApiClientCodeGen.Core.Tests.csproj -f net6.0
 
     - name: Core Integration Test project
-      run: dotnet test src/Core/ApiClientCodeGen.Core.IntegrationTests/ApiClientCodeGen.Core.IntegrationTests.csproj -f netcoreapp3.1
+      run: dotnet test src/Core/ApiClientCodeGen.Core.IntegrationTests/ApiClientCodeGen.Core.IntegrationTests.csproj -f net6.0
 
   vsix:
 

--- a/src/CLI/ApiClientCodeGen.CLI.Tests/ApiClientCodeGen.CLI.Tests.csproj
+++ b/src/CLI/ApiClientCodeGen.CLI.Tests/ApiClientCodeGen.CLI.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Rapicgen.CLI.Tests</RootNamespace>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj
+++ b/src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Christian Resma Helle</Authors>
     <Product>REST API Client Code Generator CLI Tool</Product>

--- a/src/Core/ApiClientCodeGen.Core.IntegrationTests/ApiClientCodeGen.Core.IntegrationTests.csproj
+++ b/src/Core/ApiClientCodeGen.Core.IntegrationTests/ApiClientCodeGen.Core.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Core/ApiClientCodeGen.Core.Tests/ApiClientCodeGen.Core.Tests.csproj
+++ b/src/Core/ApiClientCodeGen.Core.Tests/ApiClientCodeGen.Core.Tests.csproj
@@ -6,7 +6,7 @@
 
         <LangVersion>latest</LangVersion>
 
-        <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net6.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Core/ApiClientCodeGen.Core/ApiClientCodeGen.Core.csproj
+++ b/src/Core/ApiClientCodeGen.Core/ApiClientCodeGen.Core.csproj
@@ -21,7 +21,6 @@
     <DebugType>embedded</DebugType>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IsPackable>true</IsPackable>
-    <PackAsTool>true</PackAsTool>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Core/ApiClientCodeGen.Core/ApiClientCodeGen.Core.csproj
+++ b/src/Core/ApiClientCodeGen.Core/ApiClientCodeGen.Core.csproj
@@ -7,6 +7,7 @@
     <FileVersion>1.0.0</FileVersion>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
+    <AssemblyName>Rapicgen.Core</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Core/ApiClientCodeGen.Core/ApiClientCodeGen.Core.csproj
+++ b/src/Core/ApiClientCodeGen.Core/ApiClientCodeGen.Core.csproj
@@ -3,11 +3,25 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Rapicgen.Core</RootNamespace>
+    <AssemblyName>Rapicgen.Core</AssemblyName>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <FileVersion>1.0.0</FileVersion>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
-    <AssemblyName>Rapicgen.Core</AssemblyName>
+    <PackageId>Rapicgen.Core</PackageId>
+    <Company>Christian Resma Helle</Company>
+    <Description>REST API Client Code Generator Core Library</Description>
+    <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/christianhelle/apiclientcodegen</PackageProjectUrl>
+    <PackageIconUrl>https://raw.githubusercontent.com/christianhelle/apiclientcodegen/master/src/ApiClientCodeGen.VSIX/Resources/Icon.png</PackageIconUrl>
+    <PackageIcon>icon.png</PackageIcon>
+    <RepositoryUrl>https://github.com/christianhelle/apiclientcodegen</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <DebugType>embedded</DebugType>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IsPackable>true</IsPackable>
+    <PackAsTool>true</PackAsTool>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Makefile
+++ b/src/Makefile
@@ -18,5 +18,5 @@ publish:
 	/Applications/Visual\ Studio.app/Contents/MacOS/vstool setup rep-build .
 
 test:
-	dotnet test ./Core/ApiClientCodeGen.Core.Tests/ApiClientCodeGen.Core.Tests.csproj -f netcoreapp3.1
-	dotnet test ./Core/ApiClientCodeGen.Core.IntegrationTests/ApiClientCodeGen.Core.IntegrationTests.csproj -f netcoreapp3.1
+	dotnet test ./Core/ApiClientCodeGen.Core.Tests/ApiClientCodeGen.Core.Tests.csproj -f net6.0
+	dotnet test ./Core/ApiClientCodeGen.Core.IntegrationTests/ApiClientCodeGen.Core.IntegrationTests.csproj -f net6.0


### PR DESCRIPTION
This upgrades the CLI Tool, Rapicgen to target .NET 6.0