### PR TITLE
Add support for Kiota in Visual Studio Extensions

### DIFF
--- a/src/Core/ApiClientCodeGen.Core.Tests/NuGet/PackageDependencyListProviderTests.cs
+++ b/src/Core/ApiClientCodeGen.Core.Tests/NuGet/PackageDependencyListProviderTests.cs
@@ -4,39 +4,44 @@ using FluentAssertions;
 
 namespace ApiClientCodeGen.Core.Tests.NuGet
 {
-    
     public class PackageDependencyListProviderTests
     {
         private readonly PackageDependencyListProvider sut
             = new PackageDependencyListProvider();
 
         [Xunit.Fact]
-        public void GetDependencies_NSwag_Returns_NotEmpty() 
+        public void GetDependencies_NSwag_Returns_NotEmpty()
             => sut.GetDependencies(SupportedCodeGenerator.NSwag)
                 .Should()
                 .NotBeNullOrEmpty();
 
         [Xunit.Fact]
-        public void GetDependencies_NSwagStudio_Returns_NotEmpty() 
+        public void GetDependencies_NSwagStudio_Returns_NotEmpty()
             => sut.GetDependencies(SupportedCodeGenerator.NSwagStudio)
                 .Should()
                 .NotBeNullOrEmpty();
 
         [Xunit.Fact]
-        public void GetDependencies_AutoRest_Returns_NotEmpty() 
+        public void GetDependencies_AutoRest_Returns_NotEmpty()
             => sut.GetDependencies(SupportedCodeGenerator.AutoRest)
                 .Should()
                 .NotBeNullOrEmpty();
 
         [Xunit.Fact]
-        public void GetDependencies_Swagger_Returns_NotEmpty() 
+        public void GetDependencies_Swagger_Returns_NotEmpty()
             => sut.GetDependencies(SupportedCodeGenerator.Swagger)
                 .Should()
                 .NotBeNullOrEmpty();
 
         [Xunit.Fact]
-        public void GetDependencies_OpenApi_Returns_NotEmpty() 
+        public void GetDependencies_OpenApi_Returns_NotEmpty()
             => sut.GetDependencies(SupportedCodeGenerator.OpenApi)
+                .Should()
+                .NotBeNullOrEmpty();
+
+        [Xunit.Fact]
+        public void GetDependencies_Kiota_Returns_NotEmpty()
+            => sut.GetDependencies(SupportedCodeGenerator.Kiota)
                 .Should()
                 .NotBeNullOrEmpty();
 
@@ -171,5 +176,47 @@ namespace ApiClientCodeGen.Core.Tests.NuGet
             => sut.GetDependencies(SupportedCodeGenerator.AutoRestV3)
                 .Should()
                 .Contain(PackageDependencies.AzureCore);
+
+        [Xunit.Fact]
+        public void GetDependencies_Kiota_Contains_AzureIdentity()
+            => sut.GetDependencies(SupportedCodeGenerator.Kiota)
+                .Should()
+                .Contain(PackageDependencies.AzureIdentity);
+
+        [Xunit.Fact]
+        public void GetDependencies_Kiota_Contains_MicrosoftKiotaAbstractions()
+            => sut.GetDependencies(SupportedCodeGenerator.Kiota)
+                .Should()
+                .Contain(PackageDependencies.MicrosoftKiotaAbstractions);
+
+        [Xunit.Fact]
+        public void GetDependencies_Kiota_Contains_MicrosoftKiotaAuthenticationAzure()
+            => sut.GetDependencies(SupportedCodeGenerator.Kiota)
+                .Should()
+                .Contain(PackageDependencies.MicrosoftKiotaAuthenticationAzure);
+
+        [Xunit.Fact]
+        public void GetDependencies_Kiota_Contains_MicrosoftKiotaHttpClientLibrary()
+            => sut.GetDependencies(SupportedCodeGenerator.Kiota)
+                .Should()
+                .Contain(PackageDependencies.MicrosoftKiotaHttpClientLibrary);
+
+        [Xunit.Fact]
+        public void GetDependencies_Kiota_Contains_MicrosoftKiotaSerializationForm()
+            => sut.GetDependencies(SupportedCodeGenerator.Kiota)
+                .Should()
+                .Contain(PackageDependencies.MicrosoftKiotaSerializationForm);
+
+        [Xunit.Fact]
+        public void GetDependencies_Kiota_Contains_MicrosoftKiotaSerializationJson()
+            => sut.GetDependencies(SupportedCodeGenerator.Kiota)
+                .Should()
+                .Contain(PackageDependencies.MicrosoftKiotaSerializationForm);
+
+        [Xunit.Fact]
+        public void GetDependencies_Kiota_Contains_MicrosoftKiotaSerializationText()
+            => sut.GetDependencies(SupportedCodeGenerator.Kiota)
+                .Should()
+                .Contain(PackageDependencies.MicrosoftKiotaSerializationText);
     }
 }

--- a/src/Core/ApiClientCodeGen.Core/NuGet/PackageDependencies.cs
+++ b/src/Core/ApiClientCodeGen.Core/NuGet/PackageDependencies.cs
@@ -67,5 +67,40 @@ namespace Rapicgen.Core.NuGet
             new PackageDependency(
                 "Azure.Core",
                 new Version(1, 6, 0));
+
+        public static readonly PackageDependency AzureIdentity =
+            new PackageDependency(
+                "Azure.Identity",
+                new Version(1, 8, 1));
+
+        public static readonly PackageDependency MicrosoftKiotaAbstractions =
+            new PackageDependency(
+                "Microsoft.Kiota.Abstractions",
+                "1.0.0-rc.6");
+
+        public static readonly PackageDependency MicrosoftKiotaAuthenticationAzure =
+            new PackageDependency(
+                "Microsoft.Kiota.Authentication.Azure",
+                "1.0.0-rc.3");
+
+        public static readonly PackageDependency MicrosoftKiotaHttpClientLibrary =
+            new PackageDependency(
+                "Microsoft.Kiota.Http.HttpClientLibrary",
+                "1.0.0-rc.5");
+
+        public static readonly PackageDependency MicrosoftKiotaSerializationForm =
+            new PackageDependency(
+                "Microsoft.Kiota.Serialization.Form",
+                "1.0.0-rc.3");
+
+        public static readonly PackageDependency MicrosoftKiotaSerializationJson =
+            new PackageDependency(
+                "Microsoft.Kiota.Serialization.Json",
+                "1.0.0-rc.3");
+
+        public static readonly PackageDependency MicrosoftKiotaSerializationText =
+            new PackageDependency(
+                "Microsoft.Kiota.Serialization.Text",
+                "1.0.0-rc.3");
     }
 }

--- a/src/Core/ApiClientCodeGen.Core/NuGet/PackageDependencyListProvider.cs
+++ b/src/Core/ApiClientCodeGen.Core/NuGet/PackageDependencyListProvider.cs
@@ -62,6 +62,19 @@ namespace Rapicgen.Core.NuGet
                         PackageDependencies.MicrosoftCSharp
                     });
                     break;
+
+                case SupportedCodeGenerator.Kiota:
+                    list.AddRange(new[]
+                    {
+                        PackageDependencies.AzureIdentity,
+                        PackageDependencies.MicrosoftKiotaAbstractions,
+                        PackageDependencies.MicrosoftKiotaAuthenticationAzure,
+                        PackageDependencies.MicrosoftKiotaHttpClientLibrary,
+                        PackageDependencies.MicrosoftKiotaSerializationForm,
+                        PackageDependencies.MicrosoftKiotaSerializationJson,
+                        PackageDependencies.MicrosoftKiotaSerializationText
+                    });
+                    break;
             }
             return list;
         }

--- a/src/Core/ApiClientCodeGen.Core/SupportedCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/SupportedCodeGenerator.cs
@@ -7,6 +7,7 @@
         AutoRestV3,
         Swagger,
         OpenApi,
-        NSwagStudio
+        NSwagStudio,
+        Kiota
     }
 }

--- a/src/VSIX/ApiClientCodeGen.VSIX.Dev17/VSCommandTable.vsct
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Dev17/VSCommandTable.vsct
@@ -42,12 +42,17 @@
           <ButtonText>Generate with OpenAPI Generator</ButtonText>
         </Strings>
       </Button>
-      <Button guid="guidPackageCmdSet" id="SwaggerCodeGeneratorCustomToolSetter" priority="0x0102" type="Button">
+      <Button guid="guidPackageCmdSet" id="KiotaCodeGeneratorCustomToolSetter" priority="0x0102" type="Button">
+        <Strings>
+          <ButtonText>Generate with Kiota</ButtonText>
+        </Strings>
+      </Button>
+      <Button guid="guidPackageCmdSet" id="SwaggerCodeGeneratorCustomToolSetter" priority="0x0103" type="Button">
         <Strings>
           <ButtonText>Generate with Swagger (Outdated)</ButtonText>
         </Strings>
       </Button>
-      <Button guid="guidPackageCmdSet" id="AutoRestCodeGeneratorCustomToolSetter" priority="0x0103" type="Button">
+      <Button guid="guidPackageCmdSet" id="AutoRestCodeGeneratorCustomToolSetter" priority="0x0104" type="Button">
         <Strings>
           <ButtonText>Generate with AutoRest (Unstable)</ButtonText>
         </Strings>
@@ -76,12 +81,17 @@
           <ButtonText>Generate with OpenAPI Generator</ButtonText>
         </Strings>
       </Button>
-      <Button guid="guidNewRestApiClientCmdSet" id="GenerateWithSwagger" priority="0x0103" type="Button">
+      <Button guid="guidNewRestApiClientCmdSet" id="GenerateWithKiota" priority="0x0103" type="Button">
+        <Strings>
+          <ButtonText>Generate with Kiota</ButtonText>
+        </Strings>
+      </Button>
+      <Button guid="guidNewRestApiClientCmdSet" id="GenerateWithSwagger" priority="0x0104" type="Button">
         <Strings>
           <ButtonText>Generate with Swagger (Outdated)</ButtonText>
         </Strings>
       </Button>
-      <Button guid="guidNewRestApiClientCmdSet" id="GenerateWithAutoRest" priority="0x0104" type="Button">
+      <Button guid="guidNewRestApiClientCmdSet" id="GenerateWithAutoRest" priority="0x0105" type="Button">
         <Strings>
           <ButtonText>Generate with AutoRest (Unstable)</ButtonText>
         </Strings>
@@ -106,10 +116,13 @@
     <CommandPlacement guid="guidPackageCmdSet" id="OpenApiCodeGeneratorCustomToolSetter" priority="0x0002" >
       <Parent guid="guidPackageCmdSet" id="CommandsGroup"/>
     </CommandPlacement>
-    <CommandPlacement guid="guidPackageCmdSet" id="SwaggerCodeGeneratorCustomToolSetter" priority="0x0003" >
+    <CommandPlacement guid="guidPackageCmdSet" id="KiotaCodeGeneratorCustomToolSetter" priority="0x0003" >
       <Parent guid="guidPackageCmdSet" id="CommandsGroup"/>
     </CommandPlacement>
-    <CommandPlacement guid="guidPackageCmdSet" id="AutoRestCodeGeneratorCustomToolSetter" priority="0x0004" >
+    <CommandPlacement guid="guidPackageCmdSet" id="SwaggerCodeGeneratorCustomToolSetter" priority="0x0004" >
+      <Parent guid="guidPackageCmdSet" id="CommandsGroup"/>
+    </CommandPlacement>
+    <CommandPlacement guid="guidPackageCmdSet" id="AutoRestCodeGeneratorCustomToolSetter" priority="0x0005" >
       <Parent guid="guidPackageCmdSet" id="CommandsGroup"/>
     </CommandPlacement>
 
@@ -131,10 +144,13 @@
     <CommandPlacement guid="guidNewRestApiClientCmdSet" id="GenerateWithOpenApi" priority="0x0003" >
       <Parent guid="guidNewRestApiClientCmdSet" id="NewCommandsGroup"/>
     </CommandPlacement>
-    <CommandPlacement guid="guidNewRestApiClientCmdSet" id="GenerateWithSwagger" priority="0x0004" >
+    <CommandPlacement guid="guidNewRestApiClientCmdSet" id="GenerateWithKiota" priority="0x0004" >
       <Parent guid="guidNewRestApiClientCmdSet" id="NewCommandsGroup"/>
     </CommandPlacement>
-    <CommandPlacement guid="guidNewRestApiClientCmdSet" id="GenerateWithAutoRest" priority="0x0005" >
+    <CommandPlacement guid="guidNewRestApiClientCmdSet" id="GenerateWithSwagger" priority="0x0005" >
+      <Parent guid="guidNewRestApiClientCmdSet" id="NewCommandsGroup"/>
+    </CommandPlacement>
+    <CommandPlacement guid="guidNewRestApiClientCmdSet" id="GenerateWithAutoRest" priority="0x0006" >
       <Parent guid="guidNewRestApiClientCmdSet" id="NewCommandsGroup"/>
     </CommandPlacement>
   </CommandPlacements>
@@ -156,6 +172,7 @@
       <IDSymbol name="NSwagCodeGeneratorCustomToolSetter" value="0x0300" />
       <IDSymbol name="SwaggerCodeGeneratorCustomToolSetter" value="0x0400" />
       <IDSymbol name="OpenApiCodeGeneratorCustomToolSetter" value="0x0500" />
+      <IDSymbol name="KiotaCodeGeneratorCustomToolSetter" value="0x0600" />
     </GuidSymbol>
 
     <GuidSymbol name="guidNSwagStudioContext" value="{65B3A74F-CD47-476A-A992-0C3DE31455FD}" />
@@ -173,6 +190,7 @@
       <IDSymbol name="GenerateWithSwagger" value="0x0400" />
       <IDSymbol name="GenerateWithOpenApi" value="0x0500" />
       <IDSymbol name="GenerateWithNSwagStudio" value="0x0600" />
+      <IDSymbol name="GenerateWithKiota" value="0x0700" />
     </GuidSymbol>
   </Symbols>
 </CommandTable>

--- a/src/VSIX/ApiClientCodeGen.VSIX.Shared/ApiClientCodeGen.VSIX.Shared.projitems
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Shared/ApiClientCodeGen.VSIX.Shared.projitems
@@ -27,6 +27,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)CustomTool\AutoRest\AutoRestCodeGenerator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CustomTool\AutoRest\AutoRestCSharpCodeGenerator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CustomTool\AutoRest\AutoRestVisualBasicCodeGenerator.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CustomTool\Kiota\KiotaCodeGenerator.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CustomTool\Kiota\KiotaCSharpCodeGenerator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CustomTool\NSwag\NSwagCodeGenerator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CustomTool\NSwag\NSwagCSharpCodeGenerator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CustomTool\NSwag\NSwagVisualBasicCodeGenerator.cs" />

--- a/src/VSIX/ApiClientCodeGen.VSIX.Shared/ApiClientCodeGen.VSIX.Shared.projitems
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Shared/ApiClientCodeGen.VSIX.Shared.projitems
@@ -12,6 +12,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Commands\AddNew\NewAutoRestClientCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Commands\AddNew\NewNSwagClientCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Commands\AddNew\NewNSwagStudioClientCommand.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Commands\AddNew\NewKiotaClientCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Commands\AddNew\NewOpenApiClientCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Commands\AddNew\NewRestClientCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Commands\AddNew\NewSwaggerClientCommand.cs" />
@@ -19,6 +20,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Commands\CustomTool\CustomToolSetter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Commands\CustomTool\CustomToolSetterCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Commands\CustomTool\NSwagCodeGeneratorCustomToolSetter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Commands\CustomTool\KiotaCodeGeneratorCustomToolSetter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Commands\CustomTool\OpenApiCodeGeneratorCustomToolSetter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Commands\CustomTool\SwaggerCodeGeneratorCustomToolSetter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Commands\ICommandInitializer.cs" />

--- a/src/VSIX/ApiClientCodeGen.VSIX.Shared/Commands/AddNew/NewKiotaClientCommand.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Shared/Commands/AddNew/NewKiotaClientCommand.cs
@@ -1,0 +1,13 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Rapicgen.Core;
+
+namespace Rapicgen.Commands.AddNew
+{
+    [ExcludeFromCodeCoverage]
+    public class NewKiotaClientCommand : NewRestClientCommand
+    {
+        protected override int CommandId { get; } = 0x0700;
+
+        protected override SupportedCodeGenerator CodeGenerator { get; } = SupportedCodeGenerator.Kiota;
+    }
+}

--- a/src/VSIX/ApiClientCodeGen.VSIX.Shared/Commands/CustomTool/KiotaCodeGeneratorCustomToolSetter.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Shared/Commands/CustomTool/KiotaCodeGeneratorCustomToolSetter.cs
@@ -1,0 +1,14 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Rapicgen.CustomTool.Kiota;
+
+namespace Rapicgen.Commands.CustomTool
+{
+    [ExcludeFromCodeCoverage]
+    public class KiotaCodeGeneratorCustomToolSetter
+        : CustomToolSetter<KiotaCodeGenerator>
+    {
+        public const string Name = nameof(KiotaCodeGeneratorCustomToolSetter);
+
+        protected override int CommandId { get; } = 0x0600;
+    }
+}

--- a/src/VSIX/ApiClientCodeGen.VSIX.Shared/CustomTool/Kiota/KiotaCSharpCodeGenerator.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Shared/CustomTool/Kiota/KiotaCSharpCodeGenerator.cs
@@ -1,0 +1,33 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+using Rapicgen.Core;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.TextTemplating.VSHost;
+
+namespace Rapicgen.CustomTool.Kiota
+{
+    [ExcludeFromCodeCoverage]
+    [Guid("06374E1D-C94A-431B-938D-50A9A7C1D362")]
+    [ComVisible(true)]
+    [ProvideObject(typeof(KiotaCSharpCodeGenerator))]
+    [CodeGeneratorRegistration(typeof(KiotaCSharpCodeGenerator),
+                              Description,
+                              ProvideCodeGeneratorAttribute.CSharpProjectGuid,
+                              GeneratesDesignTimeSource = true,
+                              GeneratorRegKeyName = "KiotaCodeGenerator")]
+    public class KiotaCSharpCodeGenerator : KiotaCodeGenerator
+    {
+        public const string Description = "C# Kiota Client Code Generator";
+
+        public KiotaCSharpCodeGenerator()
+            : base(SupportedLanguage.CSharp)
+        {
+        }
+
+        public override int DefaultExtension(out string pbstrDefaultExtension)
+        {
+            pbstrDefaultExtension = ".cs";
+            return 0;
+        }
+    }
+}

--- a/src/VSIX/ApiClientCodeGen.VSIX.Shared/CustomTool/Kiota/KiotaCodeGenerator.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Shared/CustomTool/Kiota/KiotaCodeGenerator.cs
@@ -1,0 +1,19 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+using Rapicgen.Core;
+using Rapicgen.Core.Converters;
+
+namespace Rapicgen.CustomTool.Kiota
+{
+    [ExcludeFromCodeCoverage]
+    [ComVisible(true)]
+    public abstract class KiotaCodeGenerator : SingleFileCodeGenerator
+    {
+        protected KiotaCodeGenerator(
+            SupportedLanguage language,
+            ILanguageConverter? languageConverter = null)
+            : base(SupportedCodeGenerator.Kiota, language)
+        {
+        }
+    }
+}

--- a/src/VSIX/ApiClientCodeGen.VSIX.Shared/Extensions/SupportedCodeGeneratorExtensions.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Shared/Extensions/SupportedCodeGeneratorExtensions.cs
@@ -4,6 +4,7 @@ using Rapicgen.CustomTool.AutoRest;
 using Rapicgen.CustomTool.NSwag;
 using Rapicgen.CustomTool.OpenApi;
 using Rapicgen.CustomTool.Swagger;
+using Rapicgen.CustomTool.Kiota;
 
 namespace Rapicgen.Extensions
 {
@@ -26,6 +27,9 @@ namespace Rapicgen.Extensions
                 case SupportedCodeGenerator.OpenApi:
                     customTool = nameof(OpenApiCodeGenerator);
                     break;
+                case SupportedCodeGenerator.Kiota:
+                    customTool = nameof(KiotaCodeGenerator);
+                    break;
             }
 
             return customTool;
@@ -44,6 +48,9 @@ namespace Rapicgen.Extensions
 
             if (type.IsAssignableFrom(typeof(OpenApiCodeGenerator)))
                 return SupportedCodeGenerator.OpenApi;
+
+            if (type.IsAssignableFrom(typeof(KiotaCodeGenerator)))
+                return SupportedCodeGenerator.Kiota;
 
             throw new NotSupportedException();
         }

--- a/src/VSIX/ApiClientCodeGen.VSIX.Shared/Generators/CodeGeneratorFactory.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Shared/Generators/CodeGeneratorFactory.cs
@@ -3,6 +3,7 @@ using Rapicgen.Core;
 using Rapicgen.Core.Extensions;
 using Rapicgen.Core.Generators;
 using Rapicgen.Core.Generators.AutoRest;
+using Rapicgen.Core.Generators.Kiota;
 using Rapicgen.Core.Generators.NSwag;
 using Rapicgen.Core.Generators.OpenApi;
 using Rapicgen.Core.Generators.Swagger;
@@ -18,8 +19,7 @@ using Rapicgen.Options.AutoRest;
 using Rapicgen.Options.General;
 using Rapicgen.Options.NSwag;
 using Rapicgen.Options.OpenApiGenerator;
-using OpenApiDocumentFactory =
-    Rapicgen.Generators.NSwag.OpenApiDocumentFactory;
+using OpenApiDocumentFactory = Rapicgen.Generators.NSwag.OpenApiDocumentFactory;
 
 namespace Rapicgen.Generators
 {
@@ -91,6 +91,13 @@ namespace Rapicgen.Generators
                         defaultNamespace,
                         optionsFactory.Create<IGeneralOptions, GeneralOptionPage, DefaultGeneralOptions>(),
                         optionsFactory.Create<IOpenApiGeneratorOptions, OpenApiGeneratorOptionsPage, DefaultOpenApiGeneratorOptions>(),
+                        processLauncher,
+                        dependencyInstaller);
+
+                case SupportedCodeGenerator.Kiota:
+                    return new KiotaCodeGenerator(
+                        inputFilePath,
+                        defaultNamespace,
                         processLauncher,
                         dependencyInstaller);
 

--- a/src/VSIX/ApiClientCodeGen.VSIX.Shared/VsPackage.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Shared/VsPackage.cs
@@ -116,10 +116,10 @@ namespace Rapicgen
             foreach (var command in commands)
                 await command.InitializeAsync(this, cancellationToken);
 
-            await TrySetupVersionTracking();
+            await TrySetupVersionTrackingAsync();
         }
 
-        private async Task TrySetupVersionTracking()
+        private async Task TrySetupVersionTrackingAsync()
         {
             try
             {

--- a/src/VSIX/ApiClientCodeGen.VSIX.Shared/VsPackage.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Shared/VsPackage.cs
@@ -90,12 +90,14 @@ namespace Rapicgen
             new NSwagCodeGeneratorCustomToolSetter(),
             new SwaggerCodeGeneratorCustomToolSetter(),
             new OpenApiCodeGeneratorCustomToolSetter(),
+            new KiotaCodeGeneratorCustomToolSetter(),
             new NSwagStudioCommand(),
             new NewAutoRestClientCommand(),
             new NewNSwagClientCommand(),
             new NewSwaggerClientCommand(),
             new NewOpenApiClientCommand(),
-            new NewNSwagStudioClientCommand()
+            new NewNSwagStudioClientCommand(),
+            new NewKiotaClientCommand()
         };
 
         public static AsyncPackage Instance { get; private set; } = null!;

--- a/src/VSIX/ApiClientCodeGen.VSIX/VSCommandTable.vsct
+++ b/src/VSIX/ApiClientCodeGen.VSIX/VSCommandTable.vsct
@@ -9,7 +9,7 @@
     <Groups>
       <Group guid="guidPackageCmdSet" id="SubmenuGroup" />
       <Group guid="guidPackageCmdSet" id="CommandsGroup" />
-
+      
       <Group guid="guidNewRestApiClientCmdSet" id="NewSubmenuGroup" />
       <Group guid="guidNewRestApiClientCmdSet" id="NewCommandsGroup" />
     </Groups>
@@ -42,12 +42,17 @@
           <ButtonText>Generate with OpenAPI Generator</ButtonText>
         </Strings>
       </Button>
-      <Button guid="guidPackageCmdSet" id="SwaggerCodeGeneratorCustomToolSetter" priority="0x0102" type="Button">
+      <Button guid="guidPackageCmdSet" id="KiotaCodeGeneratorCustomToolSetter" priority="0x0102" type="Button">
+        <Strings>
+          <ButtonText>Generate with Kiota</ButtonText>
+        </Strings>
+      </Button>
+      <Button guid="guidPackageCmdSet" id="SwaggerCodeGeneratorCustomToolSetter" priority="0x0103" type="Button">
         <Strings>
           <ButtonText>Generate with Swagger (Outdated)</ButtonText>
         </Strings>
       </Button>
-      <Button guid="guidPackageCmdSet" id="AutoRestCodeGeneratorCustomToolSetter" priority="0x0103" type="Button">
+      <Button guid="guidPackageCmdSet" id="AutoRestCodeGeneratorCustomToolSetter" priority="0x0104" type="Button">
         <Strings>
           <ButtonText>Generate with AutoRest (Unstable)</ButtonText>
         </Strings>
@@ -76,12 +81,17 @@
           <ButtonText>Generate with OpenAPI Generator</ButtonText>
         </Strings>
       </Button>
-      <Button guid="guidNewRestApiClientCmdSet" id="GenerateWithSwagger" priority="0x0103" type="Button">
+      <Button guid="guidNewRestApiClientCmdSet" id="GenerateWithKiota" priority="0x0103" type="Button">
+        <Strings>
+          <ButtonText>Generate with Kiota</ButtonText>
+        </Strings>
+      </Button>
+      <Button guid="guidNewRestApiClientCmdSet" id="GenerateWithSwagger" priority="0x0104" type="Button">
         <Strings>
           <ButtonText>Generate with Swagger (Outdated)</ButtonText>
         </Strings>
       </Button>
-      <Button guid="guidNewRestApiClientCmdSet" id="GenerateWithAutoRest" priority="0x0104" type="Button">
+      <Button guid="guidNewRestApiClientCmdSet" id="GenerateWithAutoRest" priority="0x0105" type="Button">
         <Strings>
           <ButtonText>Generate with AutoRest (Unstable)</ButtonText>
         </Strings>
@@ -106,10 +116,13 @@
     <CommandPlacement guid="guidPackageCmdSet" id="OpenApiCodeGeneratorCustomToolSetter" priority="0x0002" >
       <Parent guid="guidPackageCmdSet" id="CommandsGroup"/>
     </CommandPlacement>
-    <CommandPlacement guid="guidPackageCmdSet" id="SwaggerCodeGeneratorCustomToolSetter" priority="0x0003" >
+    <CommandPlacement guid="guidPackageCmdSet" id="KiotaCodeGeneratorCustomToolSetter" priority="0x0003" >
       <Parent guid="guidPackageCmdSet" id="CommandsGroup"/>
     </CommandPlacement>
-    <CommandPlacement guid="guidPackageCmdSet" id="AutoRestCodeGeneratorCustomToolSetter" priority="0x0004" >
+    <CommandPlacement guid="guidPackageCmdSet" id="SwaggerCodeGeneratorCustomToolSetter" priority="0x0004" >
+      <Parent guid="guidPackageCmdSet" id="CommandsGroup"/>
+    </CommandPlacement>
+    <CommandPlacement guid="guidPackageCmdSet" id="AutoRestCodeGeneratorCustomToolSetter" priority="0x0005" >
       <Parent guid="guidPackageCmdSet" id="CommandsGroup"/>
     </CommandPlacement>
 
@@ -131,10 +144,13 @@
     <CommandPlacement guid="guidNewRestApiClientCmdSet" id="GenerateWithOpenApi" priority="0x0003" >
       <Parent guid="guidNewRestApiClientCmdSet" id="NewCommandsGroup"/>
     </CommandPlacement>
-    <CommandPlacement guid="guidNewRestApiClientCmdSet" id="GenerateWithSwagger" priority="0x0004" >
+    <CommandPlacement guid="guidNewRestApiClientCmdSet" id="GenerateWithKiota" priority="0x0004" >
       <Parent guid="guidNewRestApiClientCmdSet" id="NewCommandsGroup"/>
     </CommandPlacement>
-    <CommandPlacement guid="guidNewRestApiClientCmdSet" id="GenerateWithAutoRest" priority="0x0005" >
+    <CommandPlacement guid="guidNewRestApiClientCmdSet" id="GenerateWithSwagger" priority="0x0005" >
+      <Parent guid="guidNewRestApiClientCmdSet" id="NewCommandsGroup"/>
+    </CommandPlacement>
+    <CommandPlacement guid="guidNewRestApiClientCmdSet" id="GenerateWithAutoRest" priority="0x0006" >
       <Parent guid="guidNewRestApiClientCmdSet" id="NewCommandsGroup"/>
     </CommandPlacement>
   </CommandPlacements>
@@ -156,6 +172,7 @@
       <IDSymbol name="NSwagCodeGeneratorCustomToolSetter" value="0x0300" />
       <IDSymbol name="SwaggerCodeGeneratorCustomToolSetter" value="0x0400" />
       <IDSymbol name="OpenApiCodeGeneratorCustomToolSetter" value="0x0500" />
+      <IDSymbol name="KiotaCodeGeneratorCustomToolSetter" value="0x0600" />
     </GuidSymbol>
 
     <GuidSymbol name="guidNSwagStudioContext" value="{65B3A74F-CD47-476A-A992-0C3DE31455FD}" />
@@ -173,6 +190,7 @@
       <IDSymbol name="GenerateWithSwagger" value="0x0400" />
       <IDSymbol name="GenerateWithOpenApi" value="0x0500" />
       <IDSymbol name="GenerateWithNSwagStudio" value="0x0600" />
+      <IDSymbol name="GenerateWithKiota" value="0x0700" />
     </GuidSymbol>
   </Symbols>
 </CommandTable>

--- a/src/VSIX/ApiClientCodegen.IntegrationTests/CustomTool/CSharpSingleFileCodeGeneratorTests.cs
+++ b/src/VSIX/ApiClientCodegen.IntegrationTests/CustomTool/CSharpSingleFileCodeGeneratorTests.cs
@@ -84,6 +84,12 @@ namespace Rapicgen.IntegrationTests.CustomTool
             Assert(SupportedCodeGenerator.OpenApi, optionsFactory.Object);
         }
 
+        [Fact]
+        public void Kiota_CSharp_Test()
+        {
+            Assert(SupportedCodeGenerator.Kiota);
+        }
+
         private void Assert(
             SupportedCodeGenerator generator,
             IOptionsFactory optionsFactory = null)


### PR DESCRIPTION
The changes in this pull request introduces support for generating API clients using [Microsoft Project Kiota](https://github.com/microsoft/kiota)

![vs-kiota-generator](https://user-images.githubusercontent.com/710400/216074817-98f75db0-7278-4231-acd2-aa191190feeb.png)

The Visual Studio extension will automatically install the required NuGet packages to build Kiota generated code

![vs-kiota-generator-after](https://user-images.githubusercontent.com/710400/216074834-3f7a9ce1-b347-429a-9b76-95aaaa468509.png)