### PR TITLE
OpenAPI Generator v6.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The resulting file is the equivalent of using the AutoRest CLI tool with:
 The output file is the result of merging all the files generated using the Swagger Codegen CLI tool with:
 ` generate -l csharp --input-spec [swaggerFile] --output [output] -DapiTests=false -DmodelTests=false -DpackageName=[namespace] --skip-overwrite`
 
-- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **OpenAPI Generator v6.3.0**.
+- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **[OpenAPI Generator v6.3.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v6.3.0)**.
 The output file is the result of merging all the files generated using the OpenAPI Generator tool with:
 ` generate -g csharp --input-spec [swaggerFile] --output [output] -DapiTests=false -DmodelTests=false -DpackageName=[namespace] --skip-overwrite`
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The resulting file is the equivalent of using the AutoRest CLI tool with:
 The output file is the result of merging all the files generated using the Swagger Codegen CLI tool with:
 ` generate -l csharp --input-spec [swaggerFile] --output [output] -DapiTests=false -DmodelTests=false -DpackageName=[namespace] --skip-overwrite`
 
-- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **OpenAPI Generator v6.2.1**.
+- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **OpenAPI Generator v6.3.0**.
 The output file is the result of merging all the files generated using the OpenAPI Generator tool with:
 ` generate -g csharp --input-spec [swaggerFile] --output [output] -DapiTests=false -DmodelTests=false -DpackageName=[namespace] --skip-overwrite`
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ A collection of Visual Studio C# custom tool code generators for Swagger / OpenA
 The resulting file is the equivalent of using the AutoRest CLI tool with:
 ` --csharp --input-file=[swaggerFile] --output-file=[outputFile] --namespace=[namespace] --add-credentials`
 
-- ***NSwagCodeGenerator*** - Generates a single file C# REST API Client using the [NSwag.CodeGeneration.CSharp](https://github.com/RSuter/NSwag/wiki/SwaggerToCSharpClientGenerator) [nuget package](https://www.nuget.org/packages/NSwag.CodeGeneration.CSharp/) **v13.18.2**
+- ***NSwagCodeGenerator*** - Generates a single file C# REST API Client using the [NSwag.CodeGeneration.CSharp](https://github.com/RSuter/NSwag/wiki/CSharpClientGenerator) [nuget package](https://www.nuget.org/packages/NSwag.CodeGeneration.CSharp/) **v13.18.2**
 
 - ***SwaggerCodeGenerator*** - Generates a single file C# REST API Client using **Swagger Codegen CLI v3.0.34**.
 The output file is the result of merging all the files generated using the Swagger Codegen CLI tool with:

--- a/docs/Marketplace.md
+++ b/docs/Marketplace.md
@@ -27,7 +27,7 @@ The resulting file is the equivalent of using the AutoRest CLI tool with:
 The output file is the result of merging all the files generated using the Swagger Codegen CLI tool with:
 ` generate -l csharp --input-spec [swaggerFile] --output [output] -DapiTests=false -DmodelTests=false -DpackageName=[namespace] --skip-overwrite`
 
-- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **OpenAPI Generator v6.3.0**.
+- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **[OpenAPI Generator v6.3.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v6.3.0)**.
 The output file is the result of merging all the files generated using the OpenAPI Generator tool with:
 ` generate -g csharp --input-spec [swaggerFile] --output [output] -DapiTests=false -DmodelTests=false -DpackageName=[namespace] --skip-overwrite`
 

--- a/docs/Marketplace.md
+++ b/docs/Marketplace.md
@@ -21,7 +21,7 @@ A collection of Visual Studio C# custom tool code generators for Swagger / OpenA
 The resulting file is the equivalent of using the AutoRest CLI tool with:
 ` --csharp --input-file=[swaggerFile] --output-file=[outputFile] --namespace=[namespace] --add-credentials`
 
-- ***NSwagCodeGenerator*** - Generates a single file C# REST API Client using the [NSwag.CodeGeneration.CSharp](https://github.com/RSuter/NSwag/wiki/SwaggerToCSharpClientGenerator) [nuget package](https://www.nuget.org/packages/NSwag.CodeGeneration.CSharp/) **v13.18.2**
+- ***NSwagCodeGenerator*** - Generates a single file C# REST API Client using the [NSwag.CodeGeneration.CSharp](https://github.com/RSuter/NSwag/wiki/CSharpClientGenerator) [nuget package](https://www.nuget.org/packages/NSwag.CodeGeneration.CSharp/) **v13.18.2**
 
 - ***SwaggerCodeGenerator*** - Generates a single file C# REST API Client using **Swagger Codegen CLI v3.0.34**.
 The output file is the result of merging all the files generated using the Swagger Codegen CLI tool with:

--- a/docs/Marketplace.md
+++ b/docs/Marketplace.md
@@ -27,7 +27,7 @@ The resulting file is the equivalent of using the AutoRest CLI tool with:
 The output file is the result of merging all the files generated using the Swagger Codegen CLI tool with:
 ` generate -l csharp --input-spec [swaggerFile] --output [output] -DapiTests=false -DmodelTests=false -DpackageName=[namespace] --skip-overwrite`
 
-- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **OpenAPI Generator v6.2.1**.
+- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **OpenAPI Generator v6.3.0**.
 The output file is the result of merging all the files generated using the OpenAPI Generator tool with:
 ` generate -g csharp --input-spec [swaggerFile] --output [output] -DapiTests=false -DmodelTests=false -DpackageName=[namespace] --skip-overwrite`
 

--- a/docs/Marketplace2022.md
+++ b/docs/Marketplace2022.md
@@ -27,7 +27,7 @@ The resulting file is the equivalent of using the AutoRest CLI tool with:
 The output file is the result of merging all the files generated using the Swagger Codegen CLI tool with:
 ` generate -l csharp --input-spec [swaggerFile] --output [output] -DapiTests=false -DmodelTests=false -DpackageName=[namespace] --skip-overwrite`
 
-- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **OpenAPI Generator v6.3.0**.
+- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **[OpenAPI Generator v6.3.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v6.3.0)**.
 The output file is the result of merging all the files generated using the OpenAPI Generator tool with:
 ` generate -g csharp --input-spec [swaggerFile] --output [output] -DapiTests=false -DmodelTests=false -DpackageName=[namespace] --skip-overwrite`
 

--- a/docs/Marketplace2022.md
+++ b/docs/Marketplace2022.md
@@ -21,7 +21,7 @@ A collection of Visual Studio C# custom tool code generators for Swagger / OpenA
 The resulting file is the equivalent of using the AutoRest CLI tool with:
 ` --csharp --input-file=[swaggerFile] --output-file=[outputFile] --namespace=[namespace] --add-credentials`
 
-- ***NSwagCodeGenerator*** - Generates a single file C# REST API Client using the [NSwag.CodeGeneration.CSharp](https://github.com/RSuter/NSwag/wiki/SwaggerToCSharpClientGenerator) [nuget package](https://www.nuget.org/packages/NSwag.CodeGeneration.CSharp/) **v13.18.2**
+- ***NSwagCodeGenerator*** - Generates a single file C# REST API Client using the [NSwag.CodeGeneration.CSharp](https://github.com/RSuter/NSwag/wiki/CSharpClientGenerator) [nuget package](https://www.nuget.org/packages/NSwag.CodeGeneration.CSharp/) **v13.18.2**
 
 - ***SwaggerCodeGenerator*** - Generates a single file C# REST API Client using **Swagger Codegen CLI v3.0.34**.
 The output file is the result of merging all the files generated using the Swagger Codegen CLI tool with:

--- a/docs/Marketplace2022.md
+++ b/docs/Marketplace2022.md
@@ -27,7 +27,7 @@ The resulting file is the equivalent of using the AutoRest CLI tool with:
 The output file is the result of merging all the files generated using the Swagger Codegen CLI tool with:
 ` generate -l csharp --input-spec [swaggerFile] --output [output] -DapiTests=false -DmodelTests=false -DpackageName=[namespace] --skip-overwrite`
 
-- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **OpenAPI Generator v6.2.1**.
+- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **OpenAPI Generator v6.3.0**.
 The output file is the result of merging all the files generated using the OpenAPI Generator tool with:
 ` generate -g csharp --input-spec [swaggerFile] --output [output] -DapiTests=false -DmodelTests=false -DpackageName=[namespace] --skip-overwrite`
 

--- a/docs/VisualStudioForMac.md
+++ b/docs/VisualStudioForMac.md
@@ -22,7 +22,7 @@ The resulting file is the equivalent of using the AutoRest CLI tool with:
 The output file is the result of merging all the files generated using the Swagger Codegen CLI tool with:
 ` generate -l csharp --input-spec [swaggerFile] --output [output] -DapiTests=false -DmodelTests=false -DpackageName=[namespace] --skip-overwrite`
 
-- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **OpenAPI Generator v6.3.0**.
+- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **[OpenAPI Generator v6.3.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v6.3.0)**.
 The output file is the result of merging all the files generated using the OpenAPI Generator tool with:
 ` generate -g csharp --input-spec [swaggerFile] --output [output] -DapiTests=false -DmodelTests=false -DpackageName=[namespace] --skip-overwrite`
 

--- a/docs/VisualStudioForMac.md
+++ b/docs/VisualStudioForMac.md
@@ -22,7 +22,7 @@ The resulting file is the equivalent of using the AutoRest CLI tool with:
 The output file is the result of merging all the files generated using the Swagger Codegen CLI tool with:
 ` generate -l csharp --input-spec [swaggerFile] --output [output] -DapiTests=false -DmodelTests=false -DpackageName=[namespace] --skip-overwrite`
 
-- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **OpenAPI Generator v6.2.1**.
+- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **OpenAPI Generator v6.3.0**.
 The output file is the result of merging all the files generated using the OpenAPI Generator tool with:
 ` generate -g csharp --input-spec [swaggerFile] --output [output] -DapiTests=false -DmodelTests=false -DpackageName=[namespace] --skip-overwrite`
 

--- a/docs/VisualStudioForMac.md
+++ b/docs/VisualStudioForMac.md
@@ -16,7 +16,7 @@ A collection of Visual Studio C# custom tool code generators for Swagger / OpenA
 The resulting file is the equivalent of using the AutoRest CLI tool with:
 ` --csharp --input-file=[swaggerFile] --output-file=[outputFile] --namespace=[namespace] --add-credentials`
 
-- ***NSwagCodeGenerator*** - Generates a single file C# REST API Client using the [NSwag.CodeGeneration.CSharp](https://github.com/RSuter/NSwag/wiki/SwaggerToCSharpClientGenerator) [nuget package](https://www.nuget.org/packages/NSwag.CodeGeneration.CSharp/) **v13.18.2**
+- ***NSwagCodeGenerator*** - Generates a single file C# REST API Client using the [NSwag.CodeGeneration.CSharp](https://github.com/RSuter/NSwag/wiki/CSharpClientGenerator) [nuget package](https://www.nuget.org/packages/NSwag.CodeGeneration.CSharp/) **v13.18.2**
 
 - ***SwaggerCodeGenerator*** - Generates a single file C# REST API Client using **Swagger Codegen CLI v3.0.34**.
 The output file is the result of merging all the files generated using the Swagger Codegen CLI tool with:

--- a/src/Core/ApiClientCodeGen.Core/Resource.Designer.cs
+++ b/src/Core/ApiClientCodeGen.Core/Resource.Designer.cs
@@ -78,7 +78,7 @@ namespace Rapicgen.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.2.1/openapi-generator-cli-6.2.1.jar.
+        ///   Looks up a localized string similar to https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.3.0/openapi-generator-cli-6.3.0.jar.
         /// </summary>
         public static string OpenApiGenerator_DownloadUrl {
             get {
@@ -87,7 +87,7 @@ namespace Rapicgen.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 5C4001EA5F3EF87D8E5D31569EC74A0C.
+        ///   Looks up a localized string similar to a54bd8b61de48255eda22f36e69c1761.
         /// </summary>
         public static string OpenApiGenerator_MD5 {
             get {
@@ -96,7 +96,7 @@ namespace Rapicgen.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 73B15A0F22654C5216384F7B18B44B163C98734B.
+        ///   Looks up a localized string similar to 0636e11d392a3c604d89fbc81d86701d05fe7ecf.
         /// </summary>
         public static string OpenApiGenerator_SHA1 {
             get {

--- a/src/Core/ApiClientCodeGen.Core/Resource.resx
+++ b/src/Core/ApiClientCodeGen.Core/Resource.resx
@@ -118,10 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="OpenApiGenerator_DownloadUrl" xml:space="preserve">
-    <value>https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.2.1/openapi-generator-cli-6.2.1.jar</value>
+    <value>https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.3.0/openapi-generator-cli-6.3.0.jar</value>
   </data>
   <data name="OpenApiGenerator_MD5" xml:space="preserve">
-    <value>5C4001EA5F3EF87D8E5D31569EC74A0C</value>
+    <value>a54bd8b61de48255eda22f36e69c1761</value>
   </data>
   <data name="SwaggerCodegenCli_DownloadUrl" xml:space="preserve">
     <value>https://repo1.maven.org/maven2/io/swagger/codegen/v3/swagger-codegen-cli/3.0.34/swagger-codegen-cli-3.0.34.jar</value>
@@ -130,7 +130,7 @@
     <value>A91658FA5F85D8501D0FB5E4501D35CF</value>
   </data>
   <data name="OpenApiGenerator_SHA1" xml:space="preserve">
-    <value>73B15A0F22654C5216384F7B18B44B163C98734B</value>
+    <value>0636e11d392a3c604d89fbc81d86701d05fe7ecf</value>
   </data>
   <data name="SwaggerCodegenCli_SHA1" xml:space="preserve">
     <value>54EB5F2561C77D23AF3FA2E4CEA8A100BA8F71C8</value>


### PR DESCRIPTION
The changes upgrades [OpenAPI Generator](https://github.com/OpenAPITools/openapi-generator) to [v6.3.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v6.3.0)