### PR TITLE
Enable ARM64 support for Visual Studio 2022 extension

### DIFF
--- a/src/VSIX/ApiClientCodeGen.VSIX.Dev17/source.extension.vsixmanifest
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Dev17/source.extension.vsixmanifest
@@ -11,8 +11,11 @@
         <Tags>OpenAPI; Swagger; NSwag; AutoRest; Refit; REST API; Code Generator</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)">
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,18.0)">
             <ProductArchitecture>amd64</ProductArchitecture>
+        </InstallationTarget>
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,18.0)">
+            <ProductArchitecture>arm64</ProductArchitecture>
         </InstallationTarget>
     </Installation>
     <Dependencies>

--- a/src/VSIX/ApiClientCodeGen.VSIX.Dev17/source.extension.vsixmanifest
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Dev17/source.extension.vsixmanifest
@@ -17,6 +17,9 @@
         <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,18.0)">
             <ProductArchitecture>arm64</ProductArchitecture>
         </InstallationTarget>
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,18.0)">
+            <ProductArchitecture>x86</ProductArchitecture>
+        </InstallationTarget>
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.7.2)" />


### PR DESCRIPTION
This feature is **100% UNTESTED** as I don't have ARM64 hardware