### PR TITLE
Downgrade Moq to 4.18.4 for privacy reasons

### DIFF
--- a/src/Core/ApiClientCodeGen.Tests.Common/ApiClientCodeGen.Tests.Common.csproj
+++ b/src/Core/ApiClientCodeGen.Tests.Common/ApiClientCodeGen.Tests.Common.csproj
@@ -46,7 +46,7 @@
     <PackageReference Include="AutoFixture" Version="4.18.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.0" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
-    <PackageReference Include="Moq" Version="4.20.1" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.0">

--- a/src/VSIX/ApiClientCodeGen.Tests/ApiClientCodeGen.Tests.csproj
+++ b/src/VSIX/ApiClientCodeGen.Tests/ApiClientCodeGen.Tests.csproj
@@ -134,7 +134,7 @@
       <Version>6.11.0</Version>
     </PackageReference>
     <PackageReference Include="Moq">
-      <Version>4.20.1</Version>
+      <Version>4.18.4</Version>
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.5.0</Version>

--- a/src/VSIX/ApiClientCodegen.IntegrationTests/ApiClientCodegen.IntegrationTests.csproj
+++ b/src/VSIX/ApiClientCodegen.IntegrationTests/ApiClientCodegen.IntegrationTests.csproj
@@ -114,7 +114,7 @@
       <Version>6.11.0</Version>
     </PackageReference>
     <PackageReference Include="Moq">
-      <Version>4.20.1</Version>
+      <Version>4.18.4</Version>
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.5.0</Version>


### PR DESCRIPTION
This an immediate action to the discussion in https://github.com/moq/moq/issues/1372