### PR TITLE
Add support for OpenAPI Generator configuration files

### DIFF
--- a/src/CLI/ApiClientCodeGen.CLI/Commands/CSharp/OpenApiCSharpGeneratorCommand.cs
+++ b/src/CLI/ApiClientCodeGen.CLI/Commands/CSharp/OpenApiCSharpGeneratorCommand.cs
@@ -115,6 +115,7 @@ namespace Rapicgen.CLI.Commands.CSharp
             get => openApiGeneratorOptions.SkipFormModel;
             set => openApiGeneratorOptions.SkipFormModel = value;
         }
+
         [Option(
             ShortName = "t",
             LongName = "templates",
@@ -125,6 +126,12 @@ namespace Rapicgen.CLI.Commands.CSharp
             get => openApiGeneratorOptions.TemplatesPath;
             set => openApiGeneratorOptions.TemplatesPath = value;
         }
+
+        [Option(
+            ShortName = "config",
+            LongName = "use-configuration-file",
+            Description = "Use the configuration file if present.")]
+        public bool UseConfigurationFile { get; set; }
 
         public override ICodeGenerator CreateGenerator()
             => cSharpGeneratorFactory.Create(

--- a/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiCSharpCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiCSharpCodeGenerator.cs
@@ -67,8 +67,8 @@ namespace Rapicgen.Core.Generators.OpenApi
                             $"--input-spec \"{Path.GetFileName(swaggerFile)}\" " +
                             $"--output \"{output}\" " +
                             $"--package-name \"{defaultNamespace}\" " +
-                            $"--global-property apiTests=false " +
-                            $"--global-property modelTests=false " +
+                            "--global-property apiTests=false " +
+                            "--global-property modelTests=false " +
                             $"--global-property skipFormModel={openApiGeneratorOptions.SkipFormModel} " +
                             "--skip-overwrite ";
 

--- a/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiCSharpCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiCSharpCodeGenerator.cs
@@ -72,7 +72,21 @@ namespace Rapicgen.Core.Generators.OpenApi
                             $"--global-property skipFormModel={openApiGeneratorOptions.SkipFormModel} " +
                             "--skip-overwrite ";
 
-                if (string.IsNullOrWhiteSpace(openApiGeneratorOptions.CustomAdditionalProperties))
+                if (openApiGeneratorOptions.UseConfigurationFile)
+                {
+                    var configFilename = swaggerFile
+                        .Replace(
+                            Path.GetExtension(swaggerFile),
+                            $".config{Path.GetExtension(swaggerFile)}");
+
+                    if (File.Exists(configFilename))
+                    {
+                        arguments += $"-c {configFilename}";
+                    }
+                }
+
+                if (!arguments.Contains("-c ") &&
+                    string.IsNullOrWhiteSpace(openApiGeneratorOptions.CustomAdditionalProperties))
                 {
                     arguments +=
                         "--additional-properties " +

--- a/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiCSharpCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiCSharpCodeGenerator.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.IO;
 using Rapicgen.Core.Extensions;
 using Rapicgen.Core.Installer;
@@ -74,14 +73,16 @@ namespace Rapicgen.Core.Generators.OpenApi
 
                 if (openApiGeneratorOptions.UseConfigurationFile)
                 {
-                    var configFilename = swaggerFile
-                        .Replace(
-                            Path.GetExtension(swaggerFile),
-                            $".config{Path.GetExtension(swaggerFile)}");
-
-                    if (File.Exists(configFilename))
+                    var extension = Path.GetExtension(swaggerFile);
+                    var configFilename = swaggerFile.Replace(extension, $".config{extension}");
+                    var jsonConfigFilename = swaggerFile.Replace(extension, ".config.json");
+                    var yamlConfigFilename = swaggerFile.Replace(extension, ".config.yaml");
+                    
+                    var configFilenames = new[] {configFilename, jsonConfigFilename, yamlConfigFilename};
+                    var configFile = Array.Find(configFilenames, File.Exists);
+                    if (configFile != null)
                     {
-                        arguments += $"-c {configFilename}";
+                        arguments += $"-c {configFile}";
                     }
                 }
 

--- a/src/Core/ApiClientCodeGen.Core/Options/OpenApiGenerator/DefaultOpenApiGeneratorOptions.cs
+++ b/src/Core/ApiClientCodeGen.Core/Options/OpenApiGenerator/DefaultOpenApiGeneratorOptions.cs
@@ -21,5 +21,7 @@ namespace Rapicgen.Core.Options.OpenApiGenerator
         public bool SkipFormModel { get; set; }
 
         public string? TemplatesPath { get; set; }
+
+        public bool UseConfigurationFile { get; set; } = true;
     }
 }

--- a/src/Core/ApiClientCodeGen.Core/Options/OpenApiGenerator/IOpenApiGeneratorOptions.cs
+++ b/src/Core/ApiClientCodeGen.Core/Options/OpenApiGenerator/IOpenApiGeneratorOptions.cs
@@ -11,5 +11,6 @@
         string? CustomAdditionalProperties { get; set; }
         bool SkipFormModel { get; set; }
         string? TemplatesPath { get; set; }
+        bool UseConfigurationFile { get; set; }
     }
 }

--- a/src/Core/ApiClientCodeGen.Tests.Common/ApiClientCodeGen.Tests.Common.csproj
+++ b/src/Core/ApiClientCodeGen.Tests.Common/ApiClientCodeGen.Tests.Common.csproj
@@ -40,6 +40,8 @@
     <EmbeddedResource Include="Resources\Swagger_v3.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
+    <EmbeddedResource Include="Resources\Swagger.config.json" />
+    <EmbeddedResource Include="Resources\Swagger.config.yaml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Core/ApiClientCodeGen.Tests.Common/Build/Projects/OpenApiGeneratorProjectFileContents.cs
+++ b/src/Core/ApiClientCodeGen.Tests.Common/Build/Projects/OpenApiGeneratorProjectFileContents.cs
@@ -19,6 +19,7 @@
         public const string NetStandardLibrary =
             @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
+    <LangVersion>latest</LangVersion>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Core/ApiClientCodeGen.Tests.Common/Resources/Swagger.config.json
+++ b/src/Core/ApiClientCodeGen.Tests.Common/Resources/Swagger.config.json
@@ -1,0 +1,6 @@
+{
+  "useDateTimeOffset": true,
+  "useCollection": true,
+  "returnICollection": true,
+  "interfacePrefix": "IPetstore"
+}

--- a/src/Core/ApiClientCodeGen.Tests.Common/Resources/Swagger.config.yaml
+++ b/src/Core/ApiClientCodeGen.Tests.Common/Resources/Swagger.config.yaml
@@ -1,0 +1,4 @@
+useDateTimeOffset: true
+useCollection: true
+returnICollection: true
+interfacePrefix: IPetstore

--- a/src/Core/ApiClientCodeGen.Tests.Common/TestWithResources.cs
+++ b/src/Core/ApiClientCodeGen.Tests.Common/TestWithResources.cs
@@ -18,6 +18,8 @@ namespace ApiClientCodeGen.Tests.Common
 
         public const string SwaggerJson = "Swagger.json";
         public const string SwaggerYaml = "Swagger.yaml";
+        public const string SwaggerConfigJson = "Swagger.config.json";
+        public const string SwaggerConfigYaml = "Swagger.config.yaml";
         public const string SwaggerNswag = "Swagger.nswag";
         public const string SwaggerLegacyNswag = "Swagger.legacy.nswag";
         public const string SwaggerV3Json = "Swagger_v3.json";
@@ -40,6 +42,8 @@ namespace ApiClientCodeGen.Tests.Common
             {
                 CreateFileFromEmbeddedResource(SwaggerJson);
                 CreateFileFromEmbeddedResource(SwaggerYaml);
+                CreateFileFromEmbeddedResource(SwaggerConfigJson);
+                CreateFileFromEmbeddedResource(SwaggerConfigYaml);
                 CreateFileFromEmbeddedResource(SwaggerNswag);
                 CreateFileFromEmbeddedResource(SwaggerLegacyNswag);
                 CreateFileFromEmbeddedResource(SwaggerV3Json);
@@ -49,6 +53,8 @@ namespace ApiClientCodeGen.Tests.Common
 
                 CreateFileFromEmbeddedResource(SwaggerJson, SwaggerJsonFilename);
                 CreateFileFromEmbeddedResource(SwaggerYaml, SwaggerYamlFilename);
+                CreateFileFromEmbeddedResource(SwaggerConfigJson, SwaggerJsonFilename.Replace(".json", ".config.json"));
+                CreateFileFromEmbeddedResource(SwaggerConfigYaml, SwaggerYamlFilename.Replace(".yaml", ".config.yaml"));
                 CreateFileFromEmbeddedResource(SwaggerNswag, SwaggerNSwagFilename);
                 CreateFileFromEmbeddedResource(SwaggerLegacyNswag, SwaggerLegacyNSwagFilename);
                 CreateFileFromEmbeddedResource(SwaggerV3Json, SwaggerV3JsonFilename);

--- a/src/VSIX/ApiClientCodeGen.VSIX.Shared/Options/OpenApiGenerator/OpenApiGeneratorOptions.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Shared/Options/OpenApiGenerator/OpenApiGeneratorOptions.cs
@@ -23,6 +23,7 @@ namespace Rapicgen.Options.OpenApiGenerator
                 CustomAdditionalProperties = options.CustomAdditionalProperties;
                 SkipFormModel = options.SkipFormModel;
                 TemplatesPath = options.TemplatesPath;
+                UseConfigurationFile = options.UseConfigurationFile;
             }
             catch (Exception e)
             {
@@ -40,6 +41,7 @@ namespace Rapicgen.Options.OpenApiGenerator
                 Logger.Instance.WriteLine($"CustomAdditionalProperties = {CustomAdditionalProperties}");
                 Logger.Instance.WriteLine($"SkipFormModel = {SkipFormModel}");
                 Logger.Instance.WriteLine($"TemplatesPath = {TemplatesPath}");
+                Logger.Instance.WriteLine($"UseConfigurationFile = {UseConfigurationFile}");
 
                 EmitDefaultValue = true;
             }
@@ -54,5 +56,6 @@ namespace Rapicgen.Options.OpenApiGenerator
         public string? CustomAdditionalProperties { get; set; }
         public bool SkipFormModel { get; set; }
         public string? TemplatesPath { get; set; }
+        public bool UseConfigurationFile { get; set; }
     }
 }

--- a/src/VSIX/ApiClientCodeGen.VSIX.Shared/Options/OpenApiGenerator/OpenApiGeneratorOptionsPage.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Shared/Options/OpenApiGenerator/OpenApiGeneratorOptionsPage.cs
@@ -63,6 +63,6 @@ namespace Rapicgen.Options.OpenApiGenerator
         [Category(Name)]
         [DisplayName("Use Configuration File")]
         [Description("Use the configuration file if present.")]
-        public bool UseConfigurationFile { get; set; }
+        public bool UseConfigurationFile { get; set; } = true;
     }
 }

--- a/src/VSIX/ApiClientCodeGen.VSIX.Shared/Options/OpenApiGenerator/OpenApiGeneratorOptionsPage.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Shared/Options/OpenApiGenerator/OpenApiGeneratorOptionsPage.cs
@@ -59,5 +59,10 @@ namespace Rapicgen.Options.OpenApiGenerator
         [Description("Path to the folder containing the custom Mustache templates. " +
                      "This should be either an absolute path or a path relative to the swagger file.")]
         public string? TemplatesPath { get; set; } = null!;
+
+        [Category(Name)]
+        [DisplayName("Use Configuration File")]
+        [Description("Use the configuration file if present.")]
+        public bool UseConfigurationFile { get; set; }
     }
 }


### PR DESCRIPTION
This implements #610 

The changes here allow users to include a `.config.json` or `.config.yaml` file to use an OpenAPI Generator configuration file. The configuration file must be placed right beside the OpenAPI specificaitons document and with the extension `.config.json` or `.config.yaml` depending on the format of the specifications file

It looks something like this:
![image](https://github.com/christianhelle/apiclientcodegen/assets/710400/3c625896-0e07-445e-8ad6-1b18c1ce9290)

Works with YAML too
![image](https://github.com/christianhelle/apiclientcodegen/assets/710400/f35225d7-ad9f-4922-8449-bc297caf6b4c)

It's also possible to use a YAML spec with a JSON config file
![image](https://github.com/christianhelle/apiclientcodegen/assets/710400/17fa8efa-7d01-4de5-b37c-17bdbf36879c)

And a JSON spec with a YAML config file
![image](https://github.com/christianhelle/apiclientcodegen/assets/710400/0c2e42d3-cf8b-4994-bf36-90a3e52f30b6)
