### PR TITLE
Ensure that the marketplace review link does not block status messages

### DIFF
--- a/src/VSIX/ApiClientCodeGen.VSIX.Shared/Windows/EnterOpenApiSpecDialog.Designer.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Shared/Windows/EnterOpenApiSpecDialog.Designer.cs
@@ -60,7 +60,7 @@
             // btnOK
             // 
             this.btnOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnOK.Location = new System.Drawing.Point(289, 76);
+            this.btnOK.Location = new System.Drawing.Point(289, 67);
             this.btnOK.Name = "btnOK";
             this.btnOK.Size = new System.Drawing.Size(75, 23);
             this.btnOK.TabIndex = 3;
@@ -72,7 +72,7 @@
             // 
             this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnCancel.Location = new System.Drawing.Point(370, 76);
+            this.btnCancel.Location = new System.Drawing.Point(370, 67);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(75, 23);
             this.btnCancel.TabIndex = 4;
@@ -102,7 +102,7 @@
             // 
             this.lblStatus.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.lblStatus.AutoSize = true;
-            this.lblStatus.Location = new System.Drawing.Point(12, 91);
+            this.lblStatus.Location = new System.Drawing.Point(12, 101);
             this.lblStatus.Name = "lblStatus";
             this.lblStatus.Size = new System.Drawing.Size(0, 13);
             this.lblStatus.TabIndex = 8;
@@ -111,7 +111,7 @@
             // 
             this.btnAddCustomHeaders.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.btnAddCustomHeaders.AutoSize = true;
-            this.btnAddCustomHeaders.Location = new System.Drawing.Point(451, 76);
+            this.btnAddCustomHeaders.Location = new System.Drawing.Point(451, 67);
             this.btnAddCustomHeaders.Name = "btnAddCustomHeaders";
             this.btnAddCustomHeaders.Size = new System.Drawing.Size(89, 23);
             this.btnAddCustomHeaders.TabIndex = 9;
@@ -123,7 +123,7 @@
             // 
             this.lblMarketplaceLink.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.lblMarketplaceLink.AutoSize = true;
-            this.lblMarketplaceLink.Location = new System.Drawing.Point(5, 95);
+            this.lblMarketplaceLink.Location = new System.Drawing.Point(5, 105);
             this.lblMarketplaceLink.Name = "lblMarketplaceLink";
             this.lblMarketplaceLink.Size = new System.Drawing.Size(265, 13);
             this.lblMarketplaceLink.TabIndex = 10;
@@ -138,7 +138,7 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSize = true;
             this.CancelButton = this.btnCancel;
-            this.ClientSize = new System.Drawing.Size(552, 113);
+            this.ClientSize = new System.Drawing.Size(552, 123);
             this.Controls.Add(this.lblMarketplaceLink);
             this.Controls.Add(this.btnAddCustomHeaders);
             this.Controls.Add(this.lblStatus);

--- a/src/VSIX/ApiClientCodeGen.VSIX.Shared/Windows/EnterOpenApiSpecDialog.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Shared/Windows/EnterOpenApiSpecDialog.cs
@@ -56,7 +56,7 @@ namespace Rapicgen.Windows
             var url = tbUrl.Text;
             if (string.IsNullOrWhiteSpace(url))
             {
-                lblStatus.Text = @"Please enter the URL";
+                ShowStatusMessage(@"Please enter the URL");
                 return;
             }
 
@@ -65,12 +65,12 @@ namespace Rapicgen.Windows
 
             try
             {
-                lblStatus.Text = "Downloading...";
+                ShowStatusMessage("Downloading...");
 
                 var openApiSpecification = await DownloadOpenApiSpecAsync();
                 if (string.IsNullOrWhiteSpace(openApiSpecification))
                 {
-                    lblStatus.Text = "No content!";
+                    ShowStatusMessage("No content!");
                     Logger.Instance.WriteLine($"Unable to download OpenAPI specification file from {url}");
                     return;
                 }
@@ -89,29 +89,35 @@ namespace Rapicgen.Windows
             catch (UriFormatException ex)
             {
                 const string message = "Invalid URL";
-                lblStatus.Text = message;
+                ShowStatusMessage(message);
                 Logger.Instance.WriteLine(message);
                 Logger.Instance.WriteLine(ex);
             }
             catch (HttpRequestException ex)
             {
-                lblStatus.Text = ex.Message;
+                ShowStatusMessage(ex.Message);
                 Logger.Instance.WriteLine(ex.Message);
                 Logger.Instance.WriteLine(ex);
             }
-            catch (SocketException ex) 
+            catch (SocketException ex)
             {
-                lblStatus.Text = ex.Message;
+                ShowStatusMessage(ex.Message);
                 Logger.Instance.WriteLine(ex.Message);
                 Logger.Instance.WriteLine(ex);
             }
             catch (Exception ex)
             {
-                lblStatus.Text = $@"{ex.GetType().Name}: {ex.Message}";
+                ShowStatusMessage($@"{ex.GetType().Name}: {ex.Message}");
                 Logger.Instance.TrackError(ex);
                 Logger.Instance.WriteLine($"Unable to download OpenAPI specification file from {url}");
                 Logger.Instance.WriteLine(ex);
             }
+        }
+
+        private void ShowStatusMessage(string message)
+        {
+            lblMarketplaceLink.Visible = false;
+            lblStatus.Text = message;
         }
 
         private async Task<string> DownloadOpenApiSpecAsync()


### PR DESCRIPTION
Refactored the method of displaying status messages in `EnterOpenApiSpecDialog` to use a new private method, `ShowStatusMessage()`. This change was made to increase code reuse, improve readability and reduce the susceptibility to errors. This also makes it easier to manage and possibly change the behavior of status message display in future.

Buttons and status labels within the `EnterOpenApiSpecDialog`were slightly off in their vertical positioning. This commit adjusts the Y-coordinate for the `OK`, `Cancel`, `AddCustomHeaders` buttons and `Status` , `MarketplaceLink` labels  to ensure proper alignment and improve the visual appearance of the dialog. In addition, the overall ClientSize of the dialog has been increased to accommodate these changes without overlap.