### PR TITLE
Update VSIX build workflows to disable extension deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.3
     - name: Build
-      run: msbuild VSIX.sln /property:Configuration=Release /t:Rebuild
+      run: msbuild VSIX.sln /property:Configuration=Release /p:DeployExtension=false
       working-directory: src
     - name: Move build output
       run: |

--- a/.github/workflows/vsix.yml
+++ b/.github/workflows/vsix.yml
@@ -43,7 +43,7 @@ jobs:
       uses: microsoft/setup-msbuild@v1.3
 
     - name: Build
-      run: msbuild VSIX.sln /property:Configuration=Release /t:Rebuild
+      run: msbuild VSIX.sln /property:Configuration=Release /p:DeployExtension=false
       working-directory: src
 
     - name: Move build output

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dotnet.defaultSolution": "src/Rapicgen.sln"
+}


### PR DESCRIPTION
This pull request updates the VSIX build workflows to disable extension deployment. It includes the following commits:

- Add default solution path to .vscode settings
- Update VSIX build workflows to disable extension deployment