### PR TITLE
Fix typo "Rifitter" in Visual Studio context menus

### DIFF
--- a/src/VSIX/ApiClientCodeGen.VSIX.Dev17/VSCommandTable.vsct
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Dev17/VSCommandTable.vsct
@@ -59,7 +59,7 @@
       </Button>
       <Button guid="guidPackageCmdSet" id="RefitterCodeGeneratorCustomToolSetter" priority="0x0105" type="Button">
         <Strings>
-          <ButtonText>Generate with Rifitter (v0.9.9)</ButtonText>
+          <ButtonText>Generate with Refitter (v0.9.9)</ButtonText>
         </Strings>
       </Button>
 

--- a/src/VSIX/ApiClientCodeGen.VSIX/VSCommandTable.vsct
+++ b/src/VSIX/ApiClientCodeGen.VSIX/VSCommandTable.vsct
@@ -59,7 +59,7 @@
       </Button>
       <Button guid="guidPackageCmdSet" id="RefitterCodeGeneratorCustomToolSetter" priority="0x0105" type="Button">
         <Strings>
-          <ButtonText>Generate with Rifitter (v0.9.9)</ButtonText>
+          <ButtonText>Generate with Refitter (v0.9.9)</ButtonText>
         </Strings>
       </Button>
 


### PR DESCRIPTION
This resolves #844 