### PR TITLE
Ensure Kiota custom tool respects the Generate Multiple Files option

### DIFF
--- a/src/Core/ApiClientCodeGen.Core/Generators/Kiota/KiotaCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/Kiota/KiotaCodeGenerator.cs
@@ -21,7 +21,8 @@ public class KiotaCodeGenerator(
         pGenerateProgress?.Progress(10);
         dependencyInstaller.InstallKiota();
 
-        if (new FileInfo(swaggerFile).Name == KiotaLockFile)
+        string swaggerFilename = new FileInfo(swaggerFile).Name;
+        if (swaggerFilename == KiotaLockFile)
         {
             pGenerateProgress?.Progress(40);
             RunKiotaUpdate();
@@ -48,12 +49,21 @@ public class KiotaCodeGenerator(
             File.Exists(Path.Combine(Path.GetDirectoryName(swaggerFile)!, KiotaLockFile)))
         {
             File.Copy(
+                swaggerFile,
+                Path.Combine(outputFolder, swaggerFilename),
+                true);
+
+            File.Copy(
                 Path.Combine(Path.GetDirectoryName(swaggerFile)!, KiotaLockFile),
                 Path.Combine(outputFolder, KiotaLockFile),
                 true);
 
             pGenerateProgress?.Progress(60);
-            RunKiotaUpdate();
+
+            var arguments = $" update -o \"{outputFolder}\"";
+            using var context = new DependencyContext("Kiota", $"{Command} {arguments}");
+            processLauncher.Start(Command, arguments, outputFolder);
+            context.Succeeded();
         }
 
         pGenerateProgress?.Progress(80);


### PR DESCRIPTION
The changes here fix the issue where Kiota generates multiple files when run using the custom tool if the `kiota-lock.json` file is present

This fixes #905