### PR TITLE
Revert "Update dependency Microsoft.VSSDK.BuildTools to v17.10.2179"

### DIFF
--- a/src/VSIX/ApiClientCodeGen.VSIX.Dev17/ApiClientCodeGen.VSIX.Dev17.csproj
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Dev17/ApiClientCodeGen.VSIX.Dev17.csproj
@@ -109,7 +109,7 @@
       <Version>17.0.32112.339</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.10.2179</Version>
+      <Version>17.9.3184</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/VSIX/ApiClientCodeGen.VSIX/ApiClientCodeGen.VSIX.csproj
+++ b/src/VSIX/ApiClientCodeGen.VSIX/ApiClientCodeGen.VSIX.csproj
@@ -109,7 +109,7 @@
       <Version>15.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.10.2179</Version>
+      <Version>17.9.3184</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Reverts christianhelle/apiclientcodegen#914 because this change breaks the Azure Application Insights library