### PR TITLE
Add support for .NET 8.0 to the OpenAPI Generator target framework options

### DIFF
--- a/src/Core/ApiClientCodeGen.Core.Tests/Extensions/EnumGetDescriptionTests.cs
+++ b/src/Core/ApiClientCodeGen.Core.Tests/Extensions/EnumGetDescriptionTests.cs
@@ -16,10 +16,11 @@ namespace ApiClientCodeGen.Core.Tests.Extensions
         [InlineData(OpenApiSupportedTargetFramework.NetStandard16, "netstandard1.6")]
         [InlineData(OpenApiSupportedTargetFramework.NetStandard20, "netstandard2.0")]
         [InlineData(OpenApiSupportedTargetFramework.NetStandard21, "netstandard2.1")]
-        [InlineData(OpenApiSupportedTargetFramework.NetCoreApp31, "netcoreapp3.1")]
         [InlineData(OpenApiSupportedTargetFramework.Net47, "net47")]
-        [InlineData(OpenApiSupportedTargetFramework.Net50, "net5.0")]
+        [InlineData(OpenApiSupportedTargetFramework.Net48, "net48")]
         [InlineData(OpenApiSupportedTargetFramework.Net60, "net6.0")]
+        [InlineData(OpenApiSupportedTargetFramework.Net70, "net7.0")]
+        [InlineData(OpenApiSupportedTargetFramework.Net80, "net8.0")]
         public void GetDescription_Returns_Description(
             OpenApiSupportedTargetFramework framework,
             string expected)

--- a/src/Core/ApiClientCodeGen.Core/Options/OpenApiGenerator/OpenApiSupportedTargetFramework.cs
+++ b/src/Core/ApiClientCodeGen.Core/Options/OpenApiGenerator/OpenApiSupportedTargetFramework.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 
 namespace Rapicgen.Core.Options.OpenApiGenerator
 {
@@ -18,8 +18,8 @@ namespace Rapicgen.Core.Options.OpenApiGenerator
         NetStandard13,
         [Description("net47")]
         Net47,
-        [Description("net5.0")]
-        Net50,
+        [Description("net48")]
+        Net48,
         [Description("net6.0")]
         Net60,
         [Description("net7.0")]

--- a/src/Core/ApiClientCodeGen.Core/Options/OpenApiGenerator/OpenApiSupportedTargetFramework.cs
+++ b/src/Core/ApiClientCodeGen.Core/Options/OpenApiGenerator/OpenApiSupportedTargetFramework.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 
 namespace Rapicgen.Core.Options.OpenApiGenerator
 {
@@ -16,8 +16,6 @@ namespace Rapicgen.Core.Options.OpenApiGenerator
         NetStandard14,
         [Description("netstandard1.3")]
         NetStandard13,
-        [Description("netcoreapp3.1")]
-        NetCoreApp31,
         [Description("net47")]
         Net47,
         [Description("net5.0")]

--- a/src/Core/ApiClientCodeGen.Core/Options/OpenApiGenerator/OpenApiSupportedTargetFramework.cs
+++ b/src/Core/ApiClientCodeGen.Core/Options/OpenApiGenerator/OpenApiSupportedTargetFramework.cs
@@ -24,5 +24,9 @@ namespace Rapicgen.Core.Options.OpenApiGenerator
         Net50,
         [Description("net6.0")]
         Net60,
+        [Description("net7.0")]
+        Net70,
+        [Description("net8.0")]
+        Net80,
     }
 }


### PR DESCRIPTION
This pull request adds support for .NET 7.0 and .NET 8.0 to the OpenAPI Generator target framework options. 

This allows developers to generate code using these newer versions of .NET and also keep the options aligned with the target frameworks that OpenAPI Generator supports in their [official documentation](https://openapi-generator.tech/docs/generators/csharp/)

![image](https://github.com/user-attachments/assets/90ff3cee-728f-48c2-b2f0-33cbf5011853)

![image](https://github.com/user-attachments/assets/e288cce8-20e5-4cfe-94cb-31195419f8d7)

This resolves #960 