### PR TITLE
Using config file and addl parameters causes a command error

### DIFF
--- a/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiCSharpCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiCSharpCodeGenerator.cs
@@ -83,7 +83,7 @@ namespace Rapicgen.Core.Generators.OpenApi
                     var configFile = Array.Find(configFilenames, File.Exists);
                     if (configFile != null)
                     {
-                        arguments += $"-c \"{configFile}\"";
+                        arguments += $"-c \"{configFile}\" ";
                     }
                 }
 


### PR DESCRIPTION
Adding an extra space at the end of the -c [file] line to match the other lines.