### PR TITLE
Update Kiota package dependencies for v1.18.0  compatibility

### DIFF
--- a/src/Core/ApiClientCodeGen.Core/NuGet/PackageDependencies.cs
+++ b/src/Core/ApiClientCodeGen.Core/NuGet/PackageDependencies.cs
@@ -76,37 +76,37 @@ namespace Rapicgen.Core.NuGet
         public static readonly PackageDependency MicrosoftKiotaAbstractions =
             new PackageDependency(
                 "Microsoft.Kiota.Abstractions",
-                "1.9.1");
+                "1.12.4");
 
         public static readonly PackageDependency MicrosoftKiotaAuthenticationAzure =
             new PackageDependency(
                 "Microsoft.Kiota.Authentication.Azure",
-                "1.1.5");
+                "1.12.4");
 
         public static readonly PackageDependency MicrosoftKiotaHttpClientLibrary =
             new PackageDependency(
                 "Microsoft.Kiota.Http.HttpClientLibrary",
-                "1.4.2");
+                "1.12.4");
 
         public static readonly PackageDependency MicrosoftKiotaSerializationForm =
             new PackageDependency(
                 "Microsoft.Kiota.Serialization.Form",
-                "1.2.3");
+                "1.12.4");
 
         public static readonly PackageDependency MicrosoftKiotaSerializationJson =
             new PackageDependency(
                 "Microsoft.Kiota.Serialization.Json",
-                "1.3.2");
+                "1.12.4");
 
         public static readonly PackageDependency MicrosoftKiotaSerializationText =
             new PackageDependency(
                 "Microsoft.Kiota.Serialization.Text",
-                "1.2.0");
+                "1.12.4");
 
         public static readonly PackageDependency MicrosoftKiotaSerializationMultipart =
             new PackageDependency(
                 "Microsoft.Kiota.Serialization.Multipart",
-                "1.1.5");
+                "1.12.4");
 
         public static readonly PackageDependency Refit =
             new PackageDependency(

--- a/src/Core/ApiClientCodeGen.Tests.Common/Build/Projects/KiotaProjectFileContents.cs
+++ b/src/Core/ApiClientCodeGen.Tests.Common/Build/Projects/KiotaProjectFileContents.cs
@@ -9,12 +9,12 @@
                 <TargetFramework>net8.0</TargetFramework>
               </PropertyGroup>
               <ItemGroup>
-                  <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.9.7" />
-                  <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.4.3" />
-                  <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.2.5" />
-                  <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.3.3" />
-                  <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.1.5" />
-                  <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.2.2" />
+                <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.12.4" />
+                <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.12.4" />
+                <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.12.4" />
+                <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.12.4" />
+                <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.12.4" />
+                <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.12.4" />
               </ItemGroup>
             </Project>
             """;
@@ -26,12 +26,12 @@
                 <TargetFramework>netstandard2.1</TargetFramework>
               </PropertyGroup>
               <ItemGroup>
-                  <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.9.7" />
-                  <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.4.3" />
-                  <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.2.5" />
-                  <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.3.3" />
-                  <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.1.5" />
-                  <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.2.2" />
+                <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.12.4" />
+                <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.12.4" />
+                <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.12.4" />
+                <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.12.4" />
+                <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.12.4" />
+                <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.12.4" />
               </ItemGroup>
             </Project>
             """;


### PR DESCRIPTION
This pull request updates the Kiota package dependencies to version 1.12.4. The `Microsoft.Kiota.Abstractions`, `Microsoft.Kiota.Authentication.Azure`, `Microsoft.Kiota.Http.HttpClientLibrary`, `Microsoft.Kiota.Serialization.Form`, `Microsoft.Kiota.Serialization.Json`, `Microsoft.Kiota.Serialization.Text`, and `Microsoft.Kiota.Serialization.Multipart` packages are all updated to version 1.12.4.