### PR TITLE
Update Kiota dependencies to v1.13.0

### DIFF
--- a/src/Core/ApiClientCodeGen.Core/NuGet/PackageDependencies.cs
+++ b/src/Core/ApiClientCodeGen.Core/NuGet/PackageDependencies.cs
@@ -76,37 +76,37 @@ namespace Rapicgen.Core.NuGet
         public static readonly PackageDependency MicrosoftKiotaAbstractions =
             new PackageDependency(
                 "Microsoft.Kiota.Abstractions",
-                "1.12.4");
+                "1.13.0");
 
         public static readonly PackageDependency MicrosoftKiotaAuthenticationAzure =
             new PackageDependency(
                 "Microsoft.Kiota.Authentication.Azure",
-                "1.12.4");
+                "1.13.0");
 
         public static readonly PackageDependency MicrosoftKiotaHttpClientLibrary =
             new PackageDependency(
                 "Microsoft.Kiota.Http.HttpClientLibrary",
-                "1.12.4");
+                "1.13.0");
 
         public static readonly PackageDependency MicrosoftKiotaSerializationForm =
             new PackageDependency(
                 "Microsoft.Kiota.Serialization.Form",
-                "1.12.4");
+                "1.13.0");
 
         public static readonly PackageDependency MicrosoftKiotaSerializationJson =
             new PackageDependency(
                 "Microsoft.Kiota.Serialization.Json",
-                "1.12.4");
+                "1.13.0");
 
         public static readonly PackageDependency MicrosoftKiotaSerializationText =
             new PackageDependency(
                 "Microsoft.Kiota.Serialization.Text",
-                "1.12.4");
+                "1.13.0");
 
         public static readonly PackageDependency MicrosoftKiotaSerializationMultipart =
             new PackageDependency(
                 "Microsoft.Kiota.Serialization.Multipart",
-                "1.12.4");
+                "1.13.0");
 
         public static readonly PackageDependency Refit =
             new PackageDependency(

--- a/src/Core/ApiClientCodeGen.Tests.Common/Build/Projects/KiotaProjectFileContents.cs
+++ b/src/Core/ApiClientCodeGen.Tests.Common/Build/Projects/KiotaProjectFileContents.cs
@@ -9,12 +9,12 @@
                 <TargetFramework>net8.0</TargetFramework>
               </PropertyGroup>
               <ItemGroup>
-                <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.12.4" />
-                <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.12.4" />
-                <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.12.4" />
-                <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.12.4" />
-                <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.12.4" />
-                <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.12.4" />
+                <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.13.0" />
+                <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.13.0" />
+                <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.13.0" />
+                <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.13.0" />
+                <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.13.0" />
+                <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.13.0" />
               </ItemGroup>
             </Project>
             """;
@@ -26,12 +26,12 @@
                 <TargetFramework>netstandard2.1</TargetFramework>
               </PropertyGroup>
               <ItemGroup>
-                <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.12.4" />
-                <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.12.4" />
-                <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.12.4" />
-                <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.12.4" />
-                <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.12.4" />
-                <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.12.4" />
+                <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.13.0" />
+                <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.13.0" />
+                <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.13.0" />
+                <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.13.0" />
+                <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.13.0" />
+                <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.13.0" />
               </ItemGroup>
             </Project>
             """;

--- a/test/GeneratedCode/Kiota/Directory.build.props
+++ b/test/GeneratedCode/Kiota/Directory.build.props
@@ -3,11 +3,11 @@
     <Compile Include="../*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.12.4" />
-    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.12.4" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.12.4" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.12.4" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.12.4" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.12.4" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.13.0" />
+    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.13.0" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.13.0" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.13.0" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.13.0" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.13.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This pull request updates the Kiota dependencies to version 1.13.0. The update includes changes in the unit tests and smoke tests as well.