### PR TITLE
Add support --type-access-modifier option for Microsoft Kiota

### DIFF
--- a/src/CLI/ApiClientCodeGen.CLI/Commands/CSharp/KiotaCommand.cs
+++ b/src/CLI/ApiClientCodeGen.CLI/Commands/CSharp/KiotaCommand.cs
@@ -38,4 +38,10 @@ public class KiotaCommand : CodeGeneratorCommand, IKiotaOptions
         LongName = "generate-multiple-files",
         Description = "Set this to TRUE to generate multiple files (default: FALSE)")]
     public bool GenerateMultipleFiles { get; set; }
+
+    [Option(
+        ShortName = "tam",
+        LongName = "type-access-modifier",
+        Description = "Set the access modifier for the generated types (default: public)")]
+    public TypeAccessModifier TypeAccessModifier { get; }
 }

--- a/src/Core/ApiClientCodeGen.Core/Generators/Kiota/KiotaCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/Kiota/KiotaCodeGenerator.cs
@@ -92,7 +92,13 @@ public class KiotaCodeGenerator(
 
     private void RunKiotaGenerate(string outputFolder)
     {
-        var arguments = $" generate -l CSharp -d \"{swaggerFile}\" -o \"{outputFolder}\" -n {defaultNamespace}";
+        var arguments = $" generate " +
+                        $"-l CSharp " +
+                        $"-d \"{swaggerFile}\" " +
+                        $"-o \"{outputFolder}\" " +
+                        $"-n {defaultNamespace} " +
+                        $"--type-access-modifier {options.TypeAccessModifier}";
+
         using var context = new DependencyContext("Kiota", $"{Command} {arguments}");
         processLauncher.Start(Command, arguments);
         context.Succeeded();

--- a/src/Core/ApiClientCodeGen.Core/Generators/Kiota/KiotaConfiguration.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/Kiota/KiotaConfiguration.cs
@@ -1,51 +1,55 @@
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
+namespace Rapicgen.Core.Generators.Kiota;
+
 public class KiotaConfiguration
-    {
-        [JsonPropertyName("descriptionHash")]
-        public string? DescriptionHash { get; set; }
+{
+    [JsonPropertyName("descriptionHash")]
+    public string? DescriptionHash { get; set; }
 
-        [JsonPropertyName("descriptionLocation")]
-        public string? DescriptionLocation { get; set; }
+    [JsonPropertyName("descriptionLocation")]
+    public string? DescriptionLocation { get; set; }
 
-        [JsonPropertyName("lockFileVersion")]
-        public string? LockFileVersion { get; set; }
+    [JsonPropertyName("lockFileVersion")]
+    public string? LockFileVersion { get; set; }
 
-        [JsonPropertyName("kiotaVersion")]
-        public string? KiotaVersion { get; set; }
+    [JsonPropertyName("kiotaVersion")]
+    public string? KiotaVersion { get; set; }
 
-        [JsonPropertyName("clientClassName")]
-        public string? ClientClassName { get; set; }
+    [JsonPropertyName("clientClassName")]
+    public string? ClientClassName { get; set; }
+        
+    [JsonPropertyName("typeAccessModifier")]
+    public TypeAccessModifier? TypeAccessModifier { get; set; }
 
-        [JsonPropertyName("clientNamespaceName")]
-        public string? ClientNamespaceName { get; set; }
+    [JsonPropertyName("clientNamespaceName")]
+    public string? ClientNamespaceName { get; set; }
 
-        [JsonPropertyName("language")]
-        public string? Language { get; set; }
+    [JsonPropertyName("language")]
+    public string? Language { get; set; }
 
-        [JsonPropertyName("usesBackingStore")]
-        public bool UsesBackingStore { get; set; }
+    [JsonPropertyName("usesBackingStore")]
+    public bool UsesBackingStore { get; set; }
 
-        [JsonPropertyName("includeAdditionalData")]
-        public bool IncludeAdditionalData { get; set; }
+    [JsonPropertyName("includeAdditionalData")]
+    public bool IncludeAdditionalData { get; set; }
 
-        [JsonPropertyName("serializers")]
-        public List<string>? Serializers { get; set; }
+    [JsonPropertyName("serializers")]
+    public List<string>? Serializers { get; set; }
 
-        [JsonPropertyName("deserializers")]
-        public List<string>? Deserializers { get; set; }
+    [JsonPropertyName("deserializers")]
+    public List<string>? Deserializers { get; set; }
 
-        [JsonPropertyName("structuredMimeTypes")]
-        public List<string>? StructuredMimeTypes { get; set; }
+    [JsonPropertyName("structuredMimeTypes")]
+    public List<string>? StructuredMimeTypes { get; set; }
 
-        [JsonPropertyName("includePatterns")]
-        public List<string>? IncludePatterns { get; set; }
+    [JsonPropertyName("includePatterns")]
+    public List<string>? IncludePatterns { get; set; }
 
-        [JsonPropertyName("excludePatterns")]
-        public List<string>? ExcludePatterns { get; set; }
+    [JsonPropertyName("excludePatterns")]
+    public List<string>? ExcludePatterns { get; set; }
 
-        [JsonPropertyName("disabledValidationRules")]
-        public List<object>? DisabledValidationRules { get; set; }
-    }
-
+    [JsonPropertyName("disabledValidationRules")]
+    public List<object>? DisabledValidationRules { get; set; }
+}

--- a/src/Core/ApiClientCodeGen.Core/Generators/Kiota/TypeAccessModifier.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/Kiota/TypeAccessModifier.cs
@@ -1,0 +1,12 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Rapicgen.Core.Generators.Kiota;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum TypeAccessModifier
+{
+    Public,
+    Internal,
+    Private,
+    Protected
+}

--- a/src/Core/ApiClientCodeGen.Core/Options/Kiota/DefaultKiotaOptions.cs
+++ b/src/Core/ApiClientCodeGen.Core/Options/Kiota/DefaultKiotaOptions.cs
@@ -1,7 +1,10 @@
-﻿namespace Rapicgen.Core.Options.Kiota
+﻿using Rapicgen.Core.Generators.Kiota;
+
+namespace Rapicgen.Core.Options.Kiota
 {
     public class DefaultKiotaOptions : IKiotaOptions
     {
         public bool GenerateMultipleFiles { get; set; } = false;
+        public TypeAccessModifier TypeAccessModifier { get; set; } = TypeAccessModifier.Public;
     }
 }

--- a/src/Core/ApiClientCodeGen.Core/Options/Kiota/IKiotaOptions.cs
+++ b/src/Core/ApiClientCodeGen.Core/Options/Kiota/IKiotaOptions.cs
@@ -1,7 +1,11 @@
-﻿namespace Rapicgen.Core.Options.Kiota
+﻿using Rapicgen.Core.Generators.Kiota;
+
+namespace Rapicgen.Core.Options.Kiota
 {
     public interface IKiotaOptions
     {
         bool GenerateMultipleFiles { get; }
+        
+        TypeAccessModifier TypeAccessModifier { get; }
     }
 }

--- a/src/VSIX/ApiClientCodeGen.VSIX.Shared/Options/Kiota/KiotaOptions.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Shared/Options/Kiota/KiotaOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Rapicgen.Core.Generators.Kiota;
 using Rapicgen.Core.Logging;
 using Rapicgen.Core.Options.Kiota;
 
@@ -13,6 +14,7 @@ namespace Rapicgen.Options.Kiota
             {
                 options ??= GetFromDialogPage();
                 GenerateMultipleFiles = options.GenerateMultipleFiles;
+                TypeAccessModifier = options.TypeAccessModifier;
             }
             catch (Exception e)
             {
@@ -23,9 +25,11 @@ namespace Rapicgen.Options.Kiota
                 Logger.Instance.WriteLine("GenerateMultipleFiles = false");
 
                 GenerateMultipleFiles = false;
+                TypeAccessModifier = TypeAccessModifier.Public;
             }
         }
 
         public bool GenerateMultipleFiles { get; }
+        public TypeAccessModifier TypeAccessModifier { get; }
     }
 }

--- a/src/VSIX/ApiClientCodeGen.VSIX.Shared/Options/Kiota/KiotaOptionsPage.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Shared/Options/Kiota/KiotaOptionsPage.cs
@@ -21,6 +21,6 @@ namespace Rapicgen.Options.Kiota
         [Category(Name)]
         [DisplayName("Type Access Modifier")]
         [Description("The access modifier for the generated types")]
-        public TypeAccessModifier TypeAccessModifier { get; }
+        public TypeAccessModifier TypeAccessModifier { get; set; }
     }
 }

--- a/src/VSIX/ApiClientCodeGen.VSIX.Shared/Options/Kiota/KiotaOptionsPage.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Shared/Options/Kiota/KiotaOptionsPage.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using Rapicgen.Core.Options.Kiota;
 using Microsoft.VisualStudio.Shell;
 using System.Runtime.InteropServices;
+using Rapicgen.Core.Generators.Kiota;
 
 namespace Rapicgen.Options.Kiota
 {
@@ -16,5 +17,10 @@ namespace Rapicgen.Options.Kiota
         [DisplayName("Generate Multiple Files")]
         [Description("Generate multiple files for each operation. This only works for SDK style projects")]
         public bool GenerateMultipleFiles { get; set; }
+
+        [Category(Name)]
+        [DisplayName("Type Access Modifier")]
+        [Description("The access modifier for the generated types")]
+        public TypeAccessModifier TypeAccessModifier { get; }
     }
 }


### PR DESCRIPTION
This pull request introduces a new feature to set the access modifier for generated types in the Kiota code generator. The changes span multiple files to incorporate this new option, including modifications to configuration classes, options interfaces, and the command-line interface.

### Feature Addition: Type Access Modifier

* **Command Line Interface**:
  * [`src/CLI/ApiClientCodeGen.CLI/Commands/CSharp/KiotaCommand.cs`](diffhunk://#diff-efaa25b6f99e148545de4b8ce508e9adc655a9f045ee3d2be809eb6e77b5cc5aR41-R46): Added a new option `type-access-modifier` to set the access modifier for generated types. (`[src/CLI/ApiClientCodeGen.CLI/Commands/CSharp/KiotaCommand.csR41-R46](diffhunk://#diff-efaa25b6f99e148545de4b8ce508e9adc655a9f045ee3d2be809eb6e77b5cc5aR41-R46)`)

* **Core Generator Logic**:
  * [`src/Core/ApiClientCodeGen.Core/Generators/Kiota/KiotaCodeGenerator.cs`](diffhunk://#diff-7fc30463106e95ed84a45cd810c37e2eca28d11e43188b04cd7a198d38d46aecL95-R101): Updated the code generation command to include the `--type-access-modifier` argument. (`[src/Core/ApiClientCodeGen.Core/Generators/Kiota/KiotaCodeGenerator.csL95-R101](diffhunk://#diff-7fc30463106e95ed84a45cd810c37e2eca28d11e43188b04cd7a198d38d46aecL95-R101)`)
  * [`src/Core/ApiClientCodeGen.Core/Generators/Kiota/KiotaConfiguration.cs`](diffhunk://#diff-7feace2d70b95ce310ee50c9fb636a4b8d9a4796b920a9a4596a66ecc2464d66R23-R25): Added a new property `TypeAccessModifier` to the `KiotaConfiguration` class. (`[src/Core/ApiClientCodeGen.Core/Generators/Kiota/KiotaConfiguration.csR23-R25](diffhunk://#diff-7feace2d70b95ce310ee50c9fb636a4b8d9a4796b920a9a4596a66ecc2464d66R23-R25)`)
  * [`src/Core/ApiClientCodeGen.Core/Generators/Kiota/TypeAccessModifier.cs`](diffhunk://#diff-1bf78588b25554a1e8a3251bc00e001faae9089409d3bd460e5dfaf71f2ff59cR1-R12): Introduced a new enum `TypeAccessModifier` with possible values `Public`, `Internal`, `Private`, and `Protected`. (`[src/Core/ApiClientCodeGen.Core/Generators/Kiota/TypeAccessModifier.csR1-R12](diffhunk://#diff-1bf78588b25554a1e8a3251bc00e001faae9089409d3bd460e5dfaf71f2ff59cR1-R12)`)

* **Options and Configuration**:
  * [`src/Core/ApiClientCodeGen.Core/Options/Kiota/DefaultKiotaOptions.cs`](diffhunk://#diff-2bbe5956a3cbbef79b4698ae8d3981694a7626799e8c311d4f86c1efbcb5de0bL1-R8): Set the default value for `TypeAccessModifier` to `Public`. (`[src/Core/ApiClientCodeGen.Core/Options/Kiota/DefaultKiotaOptions.csL1-R8](diffhunk://#diff-2bbe5956a3cbbef79b4698ae8d3981694a7626799e8c311d4f86c1efbcb5de0bL1-R8)`)
  * [`src/Core/ApiClientCodeGen.Core/Options/Kiota/IKiotaOptions.cs`](diffhunk://#diff-1e6e43a207cfe718769053fafba20f0cbd6b720fa1b34d7b7ac095a72cee77b6L1-R9): Added the `TypeAccessModifier` property to the `IKiotaOptions` interface. (`[src/Core/ApiClientCodeGen.Core/Options/Kiota/IKiotaOptions.csL1-R9](diffhunk://#diff-1e6e43a207cfe718769053fafba20f0cbd6b720fa1b34d7b7ac095a72cee77b6L1-R9)`)
  * [`src/VSIX/ApiClientCodeGen.VSIX.Shared/Options/Kiota/KiotaOptions.cs`](diffhunk://#diff-e25a54913797e8b56e49a9d709c5ac22e95be8aa76bc66b3b7fecf707a9a31f2R2): Updated the `KiotaOptions` class to include the `TypeAccessModifier` property. (`[[1]](diffhunk://#diff-e25a54913797e8b56e49a9d709c5ac22e95be8aa76bc66b3b7fecf707a9a31f2R2)`, `[[2]](diffhunk://#diff-e25a54913797e8b56e49a9d709c5ac22e95be8aa76bc66b3b7fecf707a9a31f2R17)`, `[[3]](diffhunk://#diff-e25a54913797e8b56e49a9d709c5ac22e95be8aa76bc66b3b7fecf707a9a31f2R28-R33)`)
  * [`src/VSIX/ApiClientCodeGen.VSIX.Shared/Options/Kiota/KiotaOptionsPage.cs`](diffhunk://#diff-9b233eaadd335f56d9e862d7624a5f0014be876c2f58a91f9da78518a019cddaR6): Added UI elements for `TypeAccessModifier` in the options page. (`[[1]](diffhunk://#diff-9b233eaadd335f56d9e862d7624a5f0014be876c2f58a91f9da78518a019cddaR6)`, `[[2]](diffhunk://#diff-9b233eaadd335f56d9e862d7624a5f0014be876c2f58a91f9da78518a019cddaR20-R24)`)

### Screenshot
![image](https://github.com/user-attachments/assets/42f9cfe3-5e69-47ea-8e23-aab2be7702fa)
