### PR TITLE
Update MacOS runner

### DIFF
--- a/.github/workflows/production-tests.yml
+++ b/.github/workflows/production-tests.yml
@@ -16,7 +16,7 @@ jobs:
 
     name: C#
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.os == 'macos-10.15' || matrix.os == 'macos-11' || matrix.node == 12 }}
+    continue-on-error: ${{ matrix.os == 'macos-10.15' || matrix.os == 'macos-12' || matrix.node == 12 }}
     strategy:
       fail-fast: false
       matrix:
@@ -26,9 +26,9 @@ jobs:
         os: [          
           ubuntu-20.04,
           ubuntu-22.04,
-          macos-11,
           macos-12,
           macos-13,
+          macos-latest,
           windows-2019,
           windows-2022
         ]
@@ -252,8 +252,8 @@ jobs:
         os: [          
           ubuntu-20.04,
           ubuntu-22.04,
-          macos-11,
           macos-12,
+          macos-latest,
           windows-2019,
           windows-2022
         ]
@@ -304,8 +304,8 @@ jobs:
         os: [          
           ubuntu-20.04,
           ubuntu-22.04,
-          macos-11,
           macos-12,
+          macos-latest,
           windows-2019,
           windows-2022
         ]

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -17,7 +17,7 @@ jobs:
 
     name: C#
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.os == 'macos-10.15' || matrix.os == 'macos-11' || matrix.node == 12 }}
+    continue-on-error: ${{ matrix.os == 'macos-10.15' || matrix.os == 'macos-12' || matrix.node == 12 }}
     strategy:
       fail-fast: false
       matrix:
@@ -27,9 +27,9 @@ jobs:
         os: [          
           ubuntu-20.04,
           ubuntu-22.04,
-          macos-11,
           macos-12,
           macos-13,
+          macos-latest,
           windows-2019,
           windows-2022
         ]
@@ -312,8 +312,8 @@ jobs:
         os: [          
           ubuntu-20.04,
           ubuntu-22.04,
-          macos-11,
           macos-12,
+          macos-latest,
           windows-2019,
           windows-2022
         ]
@@ -361,8 +361,8 @@ jobs:
         os: [          
           ubuntu-20.04,
           ubuntu-22.04,
-          macos-11,
           macos-12,
+          macos-latest,
           windows-2019,
           windows-2022
         ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
         & $VsixPublisher publish -payload ApiClientCodeGenerator-VS2022-${{ env.VERSION }}.vsix -publishManifest src/publish-manifest-vs2022.json -ignoreWarnings 'VSIXValidatorWarning01,VSIXValidatorWarning02'
   
   VSMac:
-    runs-on: macos-12
+    runs-on: macos-latest
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         format: [ json, yaml ]
         version: [ V2, V3 ]
-        os: [ macos-12, windows-latest, ubuntu-latest ]
+        os: [ macos-latest, windows-latest, ubuntu-latest ]
 
     name: C#
     runs-on: ${{ matrix.os }}
@@ -250,7 +250,7 @@ jobs:
     - name: Generate code with Kiota
       run: dotnet run --project ../src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -- -v csharp kiota ./OpenApi.${{ matrix.format }} GeneratedCode ./GeneratedCode/Kiota/Output.cs --no-logging
       working-directory: test
-      continue-on-error: ${{ matrix.os == 'macos-12' }}
+      continue-on-error: ${{ matrix.os == 'macos-latest' }}
 
     - name: Build Kiota generated code
       run: dotnet build ./GeneratedCode/Kiota/Kiota.sln
@@ -309,7 +309,7 @@ jobs:
       matrix:
         format: [ json, yaml ]
         version: [ V2, V3 ]
-        os: [ macos-12, windows-2022, ubuntu-latest ]
+        os: [ macos-latest, windows-2022, ubuntu-latest ]
 
     name: JMeter
     runs-on: ${{ matrix.os }}
@@ -351,7 +351,7 @@ jobs:
       matrix:
         format: [ json, yaml ]
         version: [ V2, V3 ]
-        os: [ macos-12, windows-2022, ubuntu-latest ]
+        os: [ macos-latest, windows-2022, ubuntu-latest ]
 
     name: TypeScript
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -61,7 +61,7 @@ jobs:
   vsmac:
 
     name: VS Mac Extension
-    runs-on: macos-12
+    runs-on: macos-latest
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/vsmac.yml
+++ b/.github/workflows/vsmac.yml
@@ -25,7 +25,7 @@ jobs:
 
   build:
 
-    runs-on: macos-12
+    runs-on: macos-latest
     timeout-minutes: 10
 
     steps:


### PR DESCRIPTION
This pull request updates the macOS runner to use `macos-latest` instead of specific macOS versions (`macos-12`). This ensures that the latest macOS version is used for the build and testing processes.