### PR TITLE
Update Kiota dependencies to v1.16.1

### DIFF
--- a/src/Core/ApiClientCodeGen.Core/NuGet/PackageDependencies.cs
+++ b/src/Core/ApiClientCodeGen.Core/NuGet/PackageDependencies.cs
@@ -76,37 +76,37 @@ namespace Rapicgen.Core.NuGet
         public static readonly PackageDependency MicrosoftKiotaAbstractions =
             new PackageDependency(
                 "Microsoft.Kiota.Abstractions",
-                "1.16.0");
+                "1.16.1");
 
         public static readonly PackageDependency MicrosoftKiotaAuthenticationAzure =
             new PackageDependency(
                 "Microsoft.Kiota.Authentication.Azure",
-                "1.16.0");
+                "1.16.1");
 
         public static readonly PackageDependency MicrosoftKiotaHttpClientLibrary =
             new PackageDependency(
                 "Microsoft.Kiota.Http.HttpClientLibrary",
-                "1.16.0");
+                "1.16.1");
 
         public static readonly PackageDependency MicrosoftKiotaSerializationForm =
             new PackageDependency(
                 "Microsoft.Kiota.Serialization.Form",
-                "1.16.0");
+                "1.16.1");
 
         public static readonly PackageDependency MicrosoftKiotaSerializationJson =
             new PackageDependency(
                 "Microsoft.Kiota.Serialization.Json",
-                "1.16.0");
+                "1.16.1");
 
         public static readonly PackageDependency MicrosoftKiotaSerializationText =
             new PackageDependency(
                 "Microsoft.Kiota.Serialization.Text",
-                "1.16.0");
+                "1.16.1");
 
         public static readonly PackageDependency MicrosoftKiotaSerializationMultipart =
             new PackageDependency(
                 "Microsoft.Kiota.Serialization.Multipart",
-                "1.16.0");
+                "1.16.1");
 
         public static readonly PackageDependency Refit =
             new PackageDependency(

--- a/src/Core/ApiClientCodeGen.Tests.Common/Build/Projects/KiotaProjectFileContents.cs
+++ b/src/Core/ApiClientCodeGen.Tests.Common/Build/Projects/KiotaProjectFileContents.cs
@@ -9,12 +9,12 @@
                 <TargetFramework>net8.0</TargetFramework>
               </PropertyGroup>
               <ItemGroup>
-                <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.16.0" />
-                <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.16.0" />
-                <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.16.0" />
-                <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.16.0" />
-                <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.16.0" />
-                <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.16.0" />
+                <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.16.1" />
+                <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.16.1" />
+                <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.16.1" />
+                <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.16.1" />
+                <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.16.1" />
+                <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.16.1" />
               </ItemGroup>
             </Project>
             """;
@@ -26,12 +26,12 @@
                 <TargetFramework>netstandard2.1</TargetFramework>
               </PropertyGroup>
               <ItemGroup>
-                <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.16.0" />
-                <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.16.0" />
-                <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.16.0" />
-                <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.16.0" />
-                <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.16.0" />
-                <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.16.0" />
+                <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.16.1" />
+                <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.16.1" />
+                <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.16.1" />
+                <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.16.1" />
+                <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.16.1" />
+                <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.16.1" />
               </ItemGroup>
             </Project>
             """;

--- a/test/GeneratedCode/Kiota/Directory.build.props
+++ b/test/GeneratedCode/Kiota/Directory.build.props
@@ -3,11 +3,11 @@
     <Compile Include="../*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.16.0" />
-    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.16.0" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.16.0" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.16.0" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.16.0" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.16.0" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.16.1" />
+    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.16.1" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.16.1" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.16.1" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.16.1" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.16.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This pull request includes updates to the version of several `Microsoft.Kiota` package dependencies across multiple files. The most important changes include updating the package versions in `PackageDependencies.cs`, `KiotaProjectFileContents.cs`, and `Directory.build.props`.

Version updates to `Microsoft.Kiota` packages:

* [`src/Core/ApiClientCodeGen.Core/NuGet/PackageDependencies.cs`](diffhunk://#diff-95b74b588bc36889e73c960f7d53f320a5d4429cb817f5459fe4cae0d0f08b3cL79-R109): Updated the version of `Microsoft.Kiota` packages from `1.16.0` to `1.16.1`.
* [`src/Core/ApiClientCodeGen.Tests.Common/Build/Projects/KiotaProjectFileContents.cs`](diffhunk://#diff-4803d3275bddea639ee0b07c0b2d62a4dfc82aed8f67ead1bdb0b2df0d0e4d50L12-R17): Updated the version of `Microsoft.Kiota` packages from `1.16.0` to `1.16.1` for both `net8.0` and `netstandard2.1` target frameworks. [[1]](diffhunk://#diff-4803d3275bddea639ee0b07c0b2d62a4dfc82aed8f67ead1bdb0b2df0d0e4d50L12-R17) [[2]](diffhunk://#diff-4803d3275bddea639ee0b07c0b2d62a4dfc82aed8f67ead1bdb0b2df0d0e4d50L29-R34)
* [`test/GeneratedCode/Kiota/Directory.build.props`](diffhunk://#diff-af9b23b54505798a373e8d35c503bc5b953c4da71fc5eb588ab2d1356a3ab4ffL6-R11): Updated the version of `Microsoft.Kiota` packages from `1.16.0` to `1.16.1`.