### PR TITLE
Fix non-editable HTTP headers Grid

### DIFF
--- a/src/VSIX/ApiClientCodeGen.VSIX.Shared/Windows/AddCustomHeaderDialog.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Shared/Windows/AddCustomHeaderDialog.cs
@@ -23,7 +23,11 @@ namespace Rapicgen.Windows
 
             foreach (var keyValuePair in existingHeaders)
                 bindingList.Add(
-                    new CustomHeader(keyValuePair.Key,keyValuePair.Value));
+                    new CustomHeader
+                    {
+                        Key = keyValuePair.Key,
+                        Value = keyValuePair.Value
+                    });
         }
 
         public IReadOnlyDictionary<string, string> CustomHeaders
@@ -31,10 +35,10 @@ namespace Rapicgen.Windows
                 .Where(c => !string.IsNullOrWhiteSpace(c.Key) && !string.IsNullOrWhiteSpace(c.Value))
                 .ToDictionary(k => k.Key, v => v.Value);
 
-        private sealed record CustomHeader(string Key, string Value)
+        private sealed class CustomHeader
         {
-            public string Key { get; } = Key;
-            public string Value { get; } = Value;
+            public string Key { get; set; }
+            public string Value { get; set; }
         }
     }
 }


### PR DESCRIPTION
This pull request includes changes to the `AddCustomHeaderDialog` class in the `ApiClientCodeGen.VSIX.Shared` project. The main changes involve modifying the `CustomHeader` type to use a class instead of a record and updating how `CustomHeader` instances are created and used.

Changes to `AddCustomHeaderDialog` class:

* Modified the `CustomHeader` type from a record to a class, allowing the properties `Key` and `Value` to be settable.
* Updated the instantiation of `CustomHeader` objects to use object initializer syntax for setting `Key` and `Value` properties