### PR TITLE
Fallback to using included OpenJDK if JAVA_HOME doesn't exist

### DIFF
--- a/src/Core/ApiClientCodeGen.Core/External/JavaPathProvider.cs
+++ b/src/Core/ApiClientCodeGen.Core/External/JavaPathProvider.cs
@@ -40,6 +40,10 @@ namespace Rapicgen.Core.External
             if (CheckJavaVersion("java"))
                 return "java";
 
+            javaPath = PathProvider.GetIncludedJavaPath();
+            if (CheckJavaVersion(javaPath))
+                return javaPath;
+
             throw new MissingJavaRuntimeException("Unable to find Java executable");
         }
 


### PR DESCRIPTION
This pull request includes an important change to the `GetJavaExePath` method in the `JavaPathProvider` class. The change improves the method's ability to locate the Java executable by adding an additional check for an included Java path before throwing an exception.

* [`src/Core/ApiClientCodeGen.Core/External/JavaPathProvider.cs`](diffhunk://#diff-755514a404d98183276e58504f7331bfd4e0027c2318192bfe6b5ac6f5ca353bR43-R46): Modified the `GetJavaExePath` method to check for an included Java path using `PathProvider.GetIncludedJavaPath()` before throwing a `MissingJavaRuntimeException` if the Java executable is not found.