### PR TITLE
Update workflows to run on windows-latest

### DIFF
--- a/.github/workflows/cli-tool.yml
+++ b/.github/workflows/cli-tool.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   build:
-    runs-on: windows-lateset
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/cli-tool.yml
+++ b/.github/workflows/cli-tool.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   build:
-    runs-on: windows-2022
+    runs-on: windows-lateset
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ env:
 jobs:
 
   CLI:
-    runs-on: windows-2022
+    runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
     - name: Sets environment variables - branch-name
@@ -41,7 +41,7 @@ jobs:
           docs/CLI.md
 
   VSIX:
-    runs-on: windows-2022
+    runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
     - name: Sets environment variables - branch-name


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow files to ensure they are using the latest Windows runner. The most important changes include modifying the `runs-on` parameter in multiple workflow files.

Updates to workflow files:

* [`.github/workflows/cli-tool.yml`](diffhunk://#diff-4c3e3afa51772a5df1fbc861efdd9e0885d366fa4f3c1fe35d00bbbf5fe72eb5L27-R27): Changed the `runs-on` parameter from `windows-2022` to `windows-latest`.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L16-R16): Updated the `runs-on` parameter to `windows-latest` for both the `CLI` and `VSIX` jobs. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L16-R16) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L44-R44)