### PR TITLE
OpenAPI Generator v7.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ Custom tools let you associate a tool with an item in a project and run that too
 
 - ***NSwagCodeGenerator*** - Generates a single file C# REST API Client using the [NSwag.CodeGeneration.CSharp](https://github.com/RSuter/NSwag/wiki/CSharpClientGenerator) [nuget package](https://www.nuget.org/packages/NSwag.CodeGeneration.CSharp/) **v14.3.0**
 
-- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **[OpenAPI Generator v7.12.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.12.0)**.
+- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **[OpenAPI Generator v7.13.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.13.0)**.
 The output file is the result of merging all the files generated using the OpenAPI Generator tool with:
 `generate -g csharp --input-spec [swagger file] --output [output file] -DapiTests=false -DmodelTests=false -DpackageName=[default namespace] --skip-overwrite`. It is possible to configure the OpenAPI Generator to generate multiple files which will be placed at the same path as the OpenAPI specifications document that was used to generate code, this is done under Tools -> REST API Client Code Generator -> OpenAPI Generator and setting **Generate Multiple Files** to **true**
 
-- ***KiotaCodeGenerator*** - Generates a single file C# REST API Client using the Microsoft project **[Kiota v1.25.1](https://learn.microsoft.com/en-us/openapi/kiota/)** generator. The output file is the result of merging all the files generated using the Kiota dotnet tool with: `generate -l CSharp -d [swagger file] -o [output file] -n [default namespace]`. It is possible to configure the OpenAPI Generator to generate multiple files which will be placed at the same path as the OpenAPI specifications document that was used to generate code, this is done under Tools -> REST API Client Code Generator -> Kiota and setting **Generate Multiple Files** to **true**
+- ***KiotaCodeGenerator*** - Generates a single file C# REST API Client using the Microsoft project **[Kiota v1.25.1](https://learn.microsoft.com/en-us/openapi/kiota/)** generator. The output file is the result of merging all the files generated using the Kiota dotnet tool with: `generate -l CSharp -d [swagger file] -o [output file] -n [default namespace]`. It is possible to configure the OpenAPI Generator to generate multiple files which will be placed at the same path as the OpenAPI specifications document that was used to generate code, this is done under Tools -> REST API Client Code Generator -> Kiota and setting **Generate Multiple Files** to **true`
 
 - ***SwaggerCodeGenerator*** - Generates a single file C# REST API Client using **Swagger Codegen CLI v3.0.34**.
 The output file is the result of merging all the files generated using the Swagger Codegen CLI tool with:
@@ -267,7 +267,7 @@ Options:
 Commands:
   csharp             Generate C# API clients
   jmeter             Generate Apache JMeter test plans
-  openapi-generator  Generate code using OpenAPI Generator (v7.12.0).
+  openapi-generator  Generate code using OpenAPI Generator (v7.13.0).
                      See supported generators at https://openapi-generator.tech/docs/generators/
   typescript         Generate TypeScript API clients
 
@@ -306,7 +306,7 @@ Commands:
   autorest      AutoRest (v3.0.0-beta.20210504.2)
   kiota         Microsoft Kiota (v1.25.1)
   nswag         NSwag (v14.3.0)
-  openapi       OpenAPI Generator (v7.12.0)
+  openapi       OpenAPI Generator (v7.13.0)
   refitter      Refitter (v1.5.4)
   swagger       Swagger Codegen CLI (v3.0.34)
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -33,7 +33,7 @@ Options:
 Commands:
   csharp             Generate C# API clients
   jmeter             Generate Apache JMeter test plans
-  openapi-generator  Generate code using OpenAPI Generator (v7.12.0).
+  openapi-generator  Generate code using OpenAPI Generator (v7.13.0).
                      See supported generators at https://openapi-generator.tech/docs/generators/
   typescript         Generate TypeScript API clients
 
@@ -72,7 +72,7 @@ Commands:
   autorest      AutoRest (v3.0.0-beta.20210504.2)
   kiota         Microsoft Kiota (v1.25.1)
   nswag         NSwag (v14.3.0)
-  openapi       OpenAPI Generator (v7.12.0)
+  openapi       OpenAPI Generator (v7.13.0)
   refitter      Refitter (v1.5.4)
   swagger       Swagger Codegen CLI (v3.0.34)
 

--- a/docs/Marketplace.md
+++ b/docs/Marketplace.md
@@ -27,7 +27,7 @@ A collection of Visual Studio C# custom tool code generators for Swagger / OpenA
 
 - ***NSwagCodeGenerator*** - Generates a single file C# REST API Client using the [NSwag.CodeGeneration.CSharp](https://github.com/RSuter/NSwag/wiki/CSharpClientGenerator) [nuget package](https://www.nuget.org/packages/NSwag.CodeGeneration.CSharp/) **v14.3.0**
 
-- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **[OpenAPI Generator v7.12.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.12.0)**.
+- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **[OpenAPI Generator v7.13.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.13.0)**.
 The output file is the result of merging all the files generated using the OpenAPI Generator tool with:
 `generate -g csharp --input-spec [swagger file] --output [output file] -DapiTests=false -DmodelTests=false -DpackageName=[default namespace] --skip-overwrite`. It is possible to configure the OpenAPI Generator to generate multiple files which will be placed at the same path as the OpenAPI specifications document that was used to generate code, this is done under Tools -> REST API Client Code Generator -> OpenAPI Generator and setting **Generate Multiple Files** to **true**
 

--- a/docs/Marketplace2022.md
+++ b/docs/Marketplace2022.md
@@ -27,7 +27,7 @@ A collection of Visual Studio C# custom tool code generators for Swagger / OpenA
 
 - ***NSwagCodeGenerator*** - Generates a single file C# REST API Client using the [NSwag.CodeGeneration.CSharp](https://github.com/RSuter/NSwag/wiki/CSharpClientGenerator) [nuget package](https://www.nuget.org/packages/NSwag.CodeGeneration.CSharp/) **v14.3.0**
 
-- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **[OpenAPI Generator v7.12.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.12.0)**.
+- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **[OpenAPI Generator v7.13.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.13.0)**.
 The output file is the result of merging all the files generated using the OpenAPI Generator tool with:
 `generate -g csharp --input-spec [swagger file] --output [output file] -DapiTests=false -DmodelTests=false -DpackageName=[default namespace] --skip-overwrite`. It is possible to configure the OpenAPI Generator to generate multiple files which will be placed at the same path as the OpenAPI specifications document that was used to generate code, this is done under Tools -> REST API Client Code Generator -> OpenAPI Generator and setting **Generate Multiple Files** to **true**
 

--- a/docs/VisualStudioForMac.md
+++ b/docs/VisualStudioForMac.md
@@ -13,7 +13,7 @@ A collection of Visual Studio C# custom tool code generators for Swagger / OpenA
 
 - ***NSwagCodeGenerator*** - Generates a single file C# REST API Client using the [NSwag.CodeGeneration.CSharp](https://github.com/RSuter/NSwag/wiki/CSharpClientGenerator) [nuget package](https://www.nuget.org/packages/NSwag.CodeGeneration.CSharp/) **v14.3.0**
 
-- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **[OpenAPI Generator v7.12.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.12.0)**.
+- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **[OpenAPI Generator v7.13.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.13.0)**.
 The output file is the result of merging all the files generated using the OpenAPI Generator tool with:
 `generate -g csharp --input-spec [swagger file] --output [output file] -DapiTests=false -DmodelTests=false -DpackageName=[default namespace] --skip-overwrite`
 

--- a/src/CLI/ApiClientCodeGen.CLI/Commands/CSharp/OpenApiCSharpGeneratorCommand.cs
+++ b/src/CLI/ApiClientCodeGen.CLI/Commands/CSharp/OpenApiCSharpGeneratorCommand.cs
@@ -9,7 +9,7 @@ using Rapicgen.Core.Options.OpenApiGenerator;
 
 namespace Rapicgen.CLI.Commands.CSharp
 {
-    [Command("openapi", Description = "OpenAPI Generator (v7.12.0)")]
+    [Command("openapi", Description = "OpenAPI Generator (v7.13.0)")]
     public class OpenApiCSharpGeneratorCommand : CodeGeneratorCommand, IOpenApiGeneratorOptions
     {
         private readonly IGeneralOptions options;

--- a/src/CLI/ApiClientCodeGen.CLI/Commands/OpenApiGeneratorCommand.cs
+++ b/src/CLI/ApiClientCodeGen.CLI/Commands/OpenApiGeneratorCommand.cs
@@ -15,7 +15,7 @@ namespace Rapicgen.CLI.Commands
     [Command(
         "openapi-generator", 
         Description = 
-            @"Generate code using OpenAPI Generator (v7.12.0). 
+            @"Generate code using OpenAPI Generator (v7.13.0). 
 See supported generators at https://openapi-generator.tech/docs/generators/")]
     public class OpenApiGeneratorCommand
     {

--- a/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiCSharpCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiCSharpCodeGenerator.cs
@@ -144,8 +144,8 @@ namespace Rapicgen.Core.Generators.OpenApi
                         "OpenAPI Generator",
                         versionString);
 
-                    // v7.12.0 generates a class that conflicts with System.Net.CookieContainer
-                    if (openApiGeneratorOptions.Version == OpenApiSupportedVersion.V7120)
+                    // v7.12.0 and above generates a class that conflicts with System.Net.CookieContainer
+                    if (openApiGeneratorOptions.Version != OpenApiSupportedVersion.V7110)
                     {
                         generatedCode = generatedCode
                             .Replace("class CookieContainer", "class TokenCookieContainer")

--- a/src/Core/ApiClientCodeGen.Core/Installer/OpenApiGeneratorVersions.cs
+++ b/src/Core/ApiClientCodeGen.Core/Installer/OpenApiGeneratorVersions.cs
@@ -12,6 +12,12 @@ public static class OpenApiGeneratorVersions
     private static readonly OpenApiGeneratorVersion[] Versions =
     [
         new(
+            "7.13.0",
+            $"{DownloadUrlPrefix}/7.13.0/openapi-generator-cli-7.13.0.jar",
+            "a72c42381d7bba007d7fb17d57a6ed7bff93ce64",
+            "1a90c7cecebe2e3956b5bc5d914b643a"
+        ),
+        new(
             "7.12.0",
             $"{DownloadUrlPrefix}/7.12.0/openapi-generator-cli-7.12.0.jar",
             "2c7d5141384d2caaa2d11d370ed172525855c157",

--- a/src/Core/ApiClientCodeGen.Core/Options/OpenApiGenerator/OpenApiSupportedVersion.cs
+++ b/src/Core/ApiClientCodeGen.Core/Options/OpenApiGenerator/OpenApiSupportedVersion.cs
@@ -4,6 +4,8 @@ namespace Rapicgen.Core.Options.OpenApiGenerator;
 
 public enum OpenApiSupportedVersion
 {
+    [Description("7.13.0")]
+    V7130,
     [Description("7.12.0")]
     V7120,
     [Description("7.11.0")]

--- a/src/Core/ApiClientCodeGen.Core/Resource.Designer.cs
+++ b/src/Core/ApiClientCodeGen.Core/Resource.Designer.cs
@@ -78,7 +78,7 @@ namespace Rapicgen.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.12.0/openapi-generator-cli-7.12.0.jar.
+        ///   Looks up a localized string similar to https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.13.0/openapi-generator-cli-7.13.0.jar.
         /// </summary>
         public static string OpenApiGenerator_DownloadUrl {
             get {

--- a/src/Core/ApiClientCodeGen.Core/Resource.resx
+++ b/src/Core/ApiClientCodeGen.Core/Resource.resx
@@ -118,13 +118,13 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="OpenApiGenerator_DownloadUrl" xml:space="preserve">
-    <value>https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.12.0/openapi-generator-cli-7.12.0.jar</value>
+    <value>https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.13.0/openapi-generator-cli-7.13.0.jar</value>
   </data>
   <data name="OpenApiGenerator_MD5" xml:space="preserve">
-    <value>40770e424b885e5878471d4a19ba951b</value>
+    <value>1a90c7cecebe2e3956b5bc5d914b643a</value>
   </data>
   <data name="OpenApiGenerator_SHA1" xml:space="preserve">
-    <value>2c7d5141384d2caaa2d11d370ed172525855c157</value>
+    <value>a72c42381d7bba007d7fb17d57a6ed7bff93ce64</value>
   </data>
   <data name="SwaggerCodegenCli_DownloadUrl" xml:space="preserve">
     <value>https://repo1.maven.org/maven2/io/swagger/codegen/v3/swagger-codegen-cli/3.0.34/swagger-codegen-cli-3.0.34.jar</value>

--- a/src/VSIX/ApiClientCodeGen.VSIX.Dev17/VSCommandTable.vsct
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Dev17/VSCommandTable.vsct
@@ -39,7 +39,7 @@
       </Button>
       <Button guid="guidPackageCmdSet" id="OpenApiCodeGeneratorCustomToolSetter" priority="0x0101" type="Button">
         <Strings>
-          <ButtonText>Generate with OpenAPI Generator (v7.12.0)</ButtonText>
+          <ButtonText>Generate with OpenAPI Generator (v7.13.0)</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidPackageCmdSet" id="KiotaCodeGeneratorCustomToolSetter" priority="0x0102" type="Button">
@@ -99,7 +99,7 @@
       </Button>
       <Button guid="guidNewRestApiClientCmdSet" id="GenerateWithOpenApi" priority="0x0102" type="Button">
         <Strings>
-          <ButtonText>Generate with OpenAPI Generator (v7.12.0)</ButtonText>
+          <ButtonText>Generate with OpenAPI Generator (v7.13.0)</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidNewRestApiClientCmdSet" id="GenerateWithKiota" priority="0x0103" type="Button">

--- a/src/VSIX/ApiClientCodeGen.VSIX/VSCommandTable.vsct
+++ b/src/VSIX/ApiClientCodeGen.VSIX/VSCommandTable.vsct
@@ -39,7 +39,7 @@
       </Button>
       <Button guid="guidPackageCmdSet" id="OpenApiCodeGeneratorCustomToolSetter" priority="0x0101" type="Button">
         <Strings>
-          <ButtonText>Generate with OpenAPI Generator (v7.12.0)</ButtonText>
+          <ButtonText>Generate with OpenAPI Generator (v7.13.0)</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidPackageCmdSet" id="KiotaCodeGeneratorCustomToolSetter" priority="0x0102" type="Button">
@@ -99,7 +99,7 @@
       </Button>
       <Button guid="guidNewRestApiClientCmdSet" id="GenerateWithOpenApi" priority="0x0102" type="Button">
         <Strings>
-          <ButtonText>Generate with OpenAPI Generator (v7.12.0)</ButtonText>
+          <ButtonText>Generate with OpenAPI Generator (v7.13.0)</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidNewRestApiClientCmdSet" id="GenerateWithKiota" priority="0x0103" type="Button">

--- a/src/VSMac/ApiClientCodeGen.VSMac/Properties/Manifest.addin.xml
+++ b/src/VSMac/ApiClientCodeGen.VSMac/Properties/Manifest.addin.xml
@@ -35,7 +35,7 @@
                  defaultHandler="ApiClientCodeGen.VSMac.Commands.Handlers.AddNewNSwagStudioCommandHandler" />
 
         <Command id = "ApiClientCodeGen.VSMac.Commands.AddToProject.OpenApi"
-                 _label = "Generate with OpenAPI Generator (v7.12.0)"
+                 _label = "Generate with OpenAPI Generator (v7.13.0)"
                  defaultHandler="ApiClientCodeGen.VSMac.Commands.Handlers.AddNewOpenApiCommandHandler" />
 
         <Command id = "ApiClientCodeGen.VSMac.Commands.AddToProject.Kiota"
@@ -64,7 +64,7 @@
                  defaultHandler="ApiClientCodeGen.VSMac.Commands.Handlers.GenerateNSwagStudioCommandHandler" />
 
         <Command id = "ApiClientCodeGen.VSMac.Commands.GenerateCode.OpenApi"
-                 _label = "Generate with OpenAPI Generator (v7.12.0)"
+                 _label = "Generate with OpenAPI Generator (v7.13.0)"
                  defaultHandler="ApiClientCodeGen.VSMac.Commands.Handlers.GenerateOpenApiCommandHandler" />
 
         <Command id = "ApiClientCodeGen.VSMac.Commands.GenerateCode.Kiota"

--- a/test/utilities.ps1
+++ b/test/utilities.ps1
@@ -182,7 +182,7 @@ function Generate-Code {
             $command = "csharp swagger"
         }
         "OpenApiGenerator" { 
-            $command = "csharp openapi -v V7110"
+            $command = "csharp openapi -v V7130"
         }
         "AutoRest-V2" {
             $command = "csharp autorest"


### PR DESCRIPTION
This pull request updates the OpenAPI Generator version from `v7.12.0` to `v7.13.0` across various parts of the project, including documentation, CLI commands, and resource files. The changes ensure consistency in version references and update download URLs and hash values for the new version.

### Documentation Updates:
* Updated OpenAPI Generator version references from `v7.12.0` to `v7.13.0` in `README.md`, `docs/CLI.md`, `docs/Marketplace.md`, `docs/Marketplace2022.md`, and `docs/VisualStudioForMac.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L57-R61) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L270-R270) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L309-R309) [[4]](diffhunk://#diff-7340b8a6d2c5b52c935f75ec72038d28b8c606323ea41bd29ced4b521eae7761L36-R36) [[5]](diffhunk://#diff-2c46c1ff50c3a5e0835446aa22ad44079a6336e0d359fdc752018c284545d32cL30-R30) [[6]](diffhunk://#diff-ce2ca0110da4d4e3e004fdb0539096339f89d8123e442449c6911655d830b3a4L30-R30) [[7]](diffhunk://#diff-3beea81115df2ba10a8c6cda0f68b266facc7f69092f6ceedb4f6c1cf54993a0L16-R16)

### CLI and Core Code Updates:
* Updated CLI command descriptions and options to reflect OpenAPI Generator `v7.13.0` in `src/CLI/ApiClientCodeGen.CLI/Commands` and `src/Core/ApiClientCodeGen.Core/Options`. [[1]](diffhunk://#diff-480dd554d419c5a3c11d27c52d20604f4f20190940917a18b1b093d223b48a02L12-R12) [[2]](diffhunk://#diff-cb917461d19b8f92deb13dff4d490df3036878f5e9e79b1beb8bbd60be5138ffL18-R18) [[3]](diffhunk://#diff-f295dca58096c2b54a85fbe5bb6a74ba76f5865c295d2bbac00e60c4c57308eeR7-R8) [[4]](diffhunk://#diff-b76f5ba8f817f1b6ce8a4b80c31859d465ada91f95f8607d7edf2431f50b34b1L81-R81)

### Resource and Installer Updates:
* Added `v7.13.0` to the supported versions in `OpenApiGeneratorVersions.cs` and updated download URLs, MD5, and SHA1 hash values in `Resource.resx` and `Resource.Designer.cs`. [[1]](diffhunk://#diff-400aabea62221bfe263d40d1be5b862cee6c4eab488ff8e7bf46a243a70108d5R14-R19) [[2]](diffhunk://#diff-c8e7a3ceaed3bee1c9e6030b486d0b63a14370818ca07374b1d71cd5ac22b7a3L121-R127) [[3]](diffhunk://#diff-b76f5ba8f817f1b6ce8a4b80c31859d465ada91f95f8607d7edf2431f50b34b1L81-R81)

### Visual Studio Integration Updates:
* Updated button labels and commands in `VSCommandTable.vsct` and `Manifest.addin.xml` to use OpenAPI Generator `v7.13.0`. [[1]](diffhunk://#diff-af94e75bbbebcda7a93525a5c0fad33ce3726dd9a9861730e558457500667c67L42-R42) [[2]](diffhunk://#diff-af94e75bbbebcda7a93525a5c0fad33ce3726dd9a9861730e558457500667c67L102-R102) [[3]](diffhunk://#diff-b858b4b9c22563c8bfc80d15555bac1593702ac5547328a2b7ecf9aa4655be6fL38-R38) [[4]](diffhunk://#diff-b858b4b9c22563c8bfc80d15555bac1593702ac5547328a2b7ecf9aa4655be6fL67-R67)