### PR TITLE
Smoke tests

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -57,6 +57,7 @@ jobs:
           6.0.x
           7.0.x
           8.0.x
+          9.0.x
 
     - name: Prepare Swagger Petstore OpenAPI Spec
       run: cp ./OpenAPI/${{ matrix.version }}/Swagger.${{ matrix.format }} ./OpenApi.${{ matrix.format }}
@@ -67,6 +68,8 @@ jobs:
         dotnet run --project ../src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -- -v csharp nswag ./OpenApi.${{ matrix.format }} GeneratedCode ./GeneratedCode/NSwag/Output.cs --no-logging
         cp ./GeneratedCode/NSwag/Output.cs ./GeneratedCode/NSwag/Net6/Output.cs
         cp ./GeneratedCode/NSwag/Output.cs ./GeneratedCode/NSwag/Net7/Output.cs
+        cp ./GeneratedCode/NSwag/Output.cs ./GeneratedCode/NSwag/Net8/Output.cs
+        cp ./GeneratedCode/NSwag/Output.cs ./GeneratedCode/NSwag/Net9/Output.cs
         cp ./GeneratedCode/NSwag/Output.cs ./GeneratedCode/NSwag/Net48/Output.cs
         cp ./GeneratedCode/NSwag/Output.cs ./GeneratedCode/NSwag/Net472/Output.cs
         cp ./GeneratedCode/NSwag/Output.cs ./GeneratedCode/NSwag/Net462/Output.cs
@@ -81,6 +84,14 @@ jobs:
 
     - name: Build .NET 7 NSwag generated code
       run: dotnet build ./GeneratedCode/NSwag/Net7/Net7.csproj
+      working-directory: test
+
+    - name: Build .NET 8 NSwag generated code
+      run: dotnet build ./GeneratedCode/NSwag/Net8/Net8.csproj
+      working-directory: test
+
+    - name: Build .NET 9 NSwag generated code
+      run: dotnet build ./GeneratedCode/NSwag/Net9/Net9.csproj
       working-directory: test
 
     - name: Build .NET 4.8.1 NSwag generated code
@@ -113,6 +124,8 @@ jobs:
         dotnet run --project ../src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -- -v csharp openapi ./OpenApi.${{ matrix.format }} GeneratedCode ./GeneratedCode/OpenApiGenerator/Output.cs --no-logging
         cp ./GeneratedCode/OpenApiGenerator/Output.cs ./GeneratedCode/OpenApiGenerator/Net6/Output.cs
         cp ./GeneratedCode/OpenApiGenerator/Output.cs ./GeneratedCode/OpenApiGenerator/Net7/Output.cs
+        cp ./GeneratedCode/OpenApiGenerator/Output.cs ./GeneratedCode/OpenApiGenerator/Net8/Output.cs
+        cp ./GeneratedCode/OpenApiGenerator/Output.cs ./GeneratedCode/OpenApiGenerator/Net9/Output.cs
         cp ./GeneratedCode/OpenApiGenerator/Output.cs ./GeneratedCode/OpenApiGenerator/Net48/Output.cs
         cp ./GeneratedCode/OpenApiGenerator/Output.cs ./GeneratedCode/OpenApiGenerator/Net472/Output.cs
         cp ./GeneratedCode/OpenApiGenerator/Output.cs ./GeneratedCode/OpenApiGenerator/Net462/Output.cs
@@ -127,6 +140,14 @@ jobs:
 
     - name: Build .NET 7 OpenAPI Generator generated code
       run: dotnet build ./GeneratedCode/OpenApiGenerator/Net7/Net7.csproj
+      working-directory: test
+
+    - name: Build .NET 8 OpenAPI Generator generated code
+      run: dotnet build ./GeneratedCode/OpenApiGenerator/Net8/Net8.csproj
+      working-directory: test
+      
+    - name: Build .NET 9 OpenAPI Generator generated code
+      run: dotnet build ./GeneratedCode/OpenApiGenerator/Net9/Net9.csproj
       working-directory: test
 
     - name: Build .NET 4.8.1 OpenAPI Generator generated code
@@ -159,6 +180,8 @@ jobs:
         dotnet run --project ../src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -- -v csharp swagger ./OpenApi.${{ matrix.format }} GeneratedCode ./GeneratedCode/SwaggerCodegen/Output.cs --no-logging
         cp ./GeneratedCode/SwaggerCodegen/Output.cs ./GeneratedCode/SwaggerCodegen/Net6/Output.cs
         cp ./GeneratedCode/SwaggerCodegen/Output.cs ./GeneratedCode/SwaggerCodegen/Net7/Output.cs
+        cp ./GeneratedCode/SwaggerCodegen/Output.cs ./GeneratedCode/SwaggerCodegen/Net8/Output.cs
+        cp ./GeneratedCode/SwaggerCodegen/Output.cs ./GeneratedCode/SwaggerCodegen/Net9/Output.cs
         cp ./GeneratedCode/SwaggerCodegen/Output.cs ./GeneratedCode/SwaggerCodegen/Net48/Output.cs
         cp ./GeneratedCode/SwaggerCodegen/Output.cs ./GeneratedCode/SwaggerCodegen/Net472/Output.cs
         cp ./GeneratedCode/SwaggerCodegen/Output.cs ./GeneratedCode/SwaggerCodegen/Net462/Output.cs
@@ -173,6 +196,14 @@ jobs:
 
     - name: Build .NET 7 Swagger Codegen CLI generated code
       run: dotnet build ./GeneratedCode/SwaggerCodegen/Net7/Net7.csproj
+      working-directory: test
+
+    - name: Build .NET 8 Swagger Codegen CLI generated code
+      run: dotnet build ./GeneratedCode/SwaggerCodegen/Net8/Net8.csproj
+      working-directory: test
+      
+    - name: Build .NET 9 Swagger Codegen CLI generated code
+      run: dotnet build ./GeneratedCode/SwaggerCodegen/Net9/Net9.csproj
       working-directory: test
 
     - name: Build .NET 4.8.1 Swagger Codegen CLI generated code
@@ -205,6 +236,8 @@ jobs:
         dotnet run --project ../src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -- -v csharp autorest ./OpenApi.${{ matrix.format }} GeneratedCode ./GeneratedCode/AutoRest-${{ matrix.version }}/Output.cs --no-logging
         cp ./GeneratedCode/AutoRest-${{ matrix.version }}/Output.cs ./GeneratedCode/AutoRest-${{ matrix.version }}/Net6/Output.cs
         cp ./GeneratedCode/AutoRest-${{ matrix.version }}/Output.cs ./GeneratedCode/AutoRest-${{ matrix.version }}/Net7/Output.cs
+        cp ./GeneratedCode/AutoRest-${{ matrix.version }}/Output.cs ./GeneratedCode/AutoRest-${{ matrix.version }}/Net8/Output.cs
+        cp ./GeneratedCode/AutoRest-${{ matrix.version }}/Output.cs ./GeneratedCode/AutoRest-${{ matrix.version }}/Net9/Output.cs
         cp ./GeneratedCode/AutoRest-${{ matrix.version }}/Output.cs ./GeneratedCode/AutoRest-${{ matrix.version }}/Net48/Output.cs
         cp ./GeneratedCode/AutoRest-${{ matrix.version }}/Output.cs ./GeneratedCode/AutoRest-${{ matrix.version }}/Net472/Output.cs
         cp ./GeneratedCode/AutoRest-${{ matrix.version }}/Output.cs ./GeneratedCode/AutoRest-${{ matrix.version }}/Net462/Output.cs
@@ -220,6 +253,14 @@ jobs:
 
     - name: Build .NET 7 AutoRest generated code
       run: dotnet build ./GeneratedCode/AutoRest-${{ matrix.version }}/Net7/Net7.csproj
+      working-directory: test
+
+    - name: Build .NET 8 AutoRest generated code
+      run: dotnet build ./GeneratedCode/AutoRest-${{ matrix.version }}/Net8/Net8.csproj
+      working-directory: test
+      
+    - name: Build .NET 9 AutoRest generated code
+      run: dotnet build ./GeneratedCode/AutoRest-${{ matrix.version }}/Net9/Net9.csproj
       working-directory: test
 
     - name: Build .NET 4.8.1 AutoRest generated code
@@ -261,6 +302,8 @@ jobs:
         dotnet run --project ../src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -- -v csharp refitter ./OpenApi.${{ matrix.format }} GeneratedCode ./GeneratedCode/Refitter/Output.cs --no-logging
         cp ./GeneratedCode/Refitter/Output.cs ./GeneratedCode/Refitter/Net6/Output.cs
         cp ./GeneratedCode/Refitter/Output.cs ./GeneratedCode/Refitter/Net7/Output.cs
+        cp ./GeneratedCode/Refitter/Output.cs ./GeneratedCode/Refitter/Net8/Output.cs
+        cp ./GeneratedCode/Refitter/Output.cs ./GeneratedCode/Refitter/Net9/Output.cs
         cp ./GeneratedCode/Refitter/Output.cs ./GeneratedCode/Refitter/Net48/Output.cs
         cp ./GeneratedCode/Refitter/Output.cs ./GeneratedCode/Refitter/Net472/Output.cs
         cp ./GeneratedCode/Refitter/Output.cs ./GeneratedCode/Refitter/Net462/Output.cs
@@ -275,6 +318,14 @@ jobs:
 
     - name: Build .NET 7 Refitter generated code
       run: dotnet build ./GeneratedCode/Refitter/Net7/Net7.csproj
+      working-directory: test
+
+    - name: Build .NET 8 Refitter generated code
+      run: dotnet build ./GeneratedCode/Refitter/Net8/Net8.csproj
+      working-directory: test
+
+    - name: Build .NET 9 Refitter generated code
+      run: dotnet build ./GeneratedCode/Refitter/Net9/Net9.csproj
       working-directory: test
 
     - name: Build .NET 4.8.1 Refitter generated code
@@ -341,6 +392,7 @@ jobs:
           6.0.x
           7.0.x
           8.0.x
+          9.0.x
 
     - name: Prepare Swagger Petstore OpenAPI Spec
       run: cp ./OpenAPI/${{ matrix.version }}/Swagger.${{ matrix.format }} ./OpenApi.${{ matrix.format }}
@@ -390,6 +442,7 @@ jobs:
           6.0.x
           7.0.x
           8.0.x
+          9.0.x
 
     - name: Prepare Swagger Petstore OpenAPI Spec
       run: cp ./OpenAPI/${{ matrix.version }}/Swagger.${{ matrix.format }} ./OpenApi.${{ matrix.format }}

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -66,6 +66,8 @@ jobs:
         dotnet run --project ../src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -- -v csharp nswag ./OpenApi.${{ matrix.format }} GeneratedCode ./GeneratedCode/NSwag/Output.cs --no-logging
         cp ./GeneratedCode/NSwag/Output.cs ./GeneratedCode/NSwag/Net6/Output.cs
         cp ./GeneratedCode/NSwag/Output.cs ./GeneratedCode/NSwag/Net7/Output.cs
+        cp ./GeneratedCode/NSwag/Output.cs ./GeneratedCode/NSwag/Net8/Output.cs
+        cp ./GeneratedCode/NSwag/Output.cs ./GeneratedCode/NSwag/Net9/Output.cs
         cp ./GeneratedCode/NSwag/Output.cs ./GeneratedCode/NSwag/Net48/Output.cs
         cp ./GeneratedCode/NSwag/Output.cs ./GeneratedCode/NSwag/Net472/Output.cs
         cp ./GeneratedCode/NSwag/Output.cs ./GeneratedCode/NSwag/Net462/Output.cs
@@ -80,6 +82,14 @@ jobs:
 
     - name: Build .NET 7 NSwag generated code
       run: dotnet build ./GeneratedCode/NSwag/Net7/Net7.csproj
+      working-directory: test
+
+    - name: Build .NET 8 NSwag generated code
+      run: dotnet build ./GeneratedCode/NSwag/Net8/Net8.csproj
+      working-directory: test
+
+    - name: Build .NET 9 NSwag generated code
+      run: dotnet build ./GeneratedCode/NSwag/Net9/Net9.csproj
       working-directory: test
 
     - name: Build .NET 4.8.1 NSwag generated code
@@ -112,6 +122,8 @@ jobs:
         dotnet run --project ../src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -- -v csharp openapi ./OpenApi.${{ matrix.format }} GeneratedCode ./GeneratedCode/OpenApiGenerator/Output.cs --no-logging
         cp ./GeneratedCode/OpenApiGenerator/Output.cs ./GeneratedCode/OpenApiGenerator/Net6/Output.cs
         cp ./GeneratedCode/OpenApiGenerator/Output.cs ./GeneratedCode/OpenApiGenerator/Net7/Output.cs
+        cp ./GeneratedCode/OpenApiGenerator/Output.cs ./GeneratedCode/OpenApiGenerator/Net8/Output.cs
+        cp ./GeneratedCode/OpenApiGenerator/Output.cs ./GeneratedCode/OpenApiGenerator/Net9/Output.cs
         cp ./GeneratedCode/OpenApiGenerator/Output.cs ./GeneratedCode/OpenApiGenerator/Net48/Output.cs
         cp ./GeneratedCode/OpenApiGenerator/Output.cs ./GeneratedCode/OpenApiGenerator/Net472/Output.cs
         cp ./GeneratedCode/OpenApiGenerator/Output.cs ./GeneratedCode/OpenApiGenerator/Net462/Output.cs
@@ -126,6 +138,14 @@ jobs:
 
     - name: Build .NET 7 OpenAPI Generator generated code
       run: dotnet build ./GeneratedCode/OpenApiGenerator/Net7/Net7.csproj
+      working-directory: test
+      
+    - name: Build .NET 8 OpenAPI Generator generated code
+      run: dotnet build ./GeneratedCode/OpenApiGenerator/Net8/Net8.csproj
+      working-directory: test
+      
+    - name: Build .NET 9 OpenAPI Generator generated code
+      run: dotnet build ./GeneratedCode/OpenApiGenerator/Net9/Net9.csproj
       working-directory: test
 
     - name: Build .NET 4.8.1 OpenAPI Generator generated code
@@ -158,6 +178,8 @@ jobs:
         dotnet run --project ../src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -- -v csharp swagger ./OpenApi.${{ matrix.format }} GeneratedCode ./GeneratedCode/SwaggerCodegen/Output.cs --no-logging
         cp ./GeneratedCode/SwaggerCodegen/Output.cs ./GeneratedCode/SwaggerCodegen/Net6/Output.cs
         cp ./GeneratedCode/SwaggerCodegen/Output.cs ./GeneratedCode/SwaggerCodegen/Net7/Output.cs
+        cp ./GeneratedCode/SwaggerCodegen/Output.cs ./GeneratedCode/SwaggerCodegen/Net8/Output.cs
+        cp ./GeneratedCode/SwaggerCodegen/Output.cs ./GeneratedCode/SwaggerCodegen/Net9/Output.cs
         cp ./GeneratedCode/SwaggerCodegen/Output.cs ./GeneratedCode/SwaggerCodegen/Net48/Output.cs
         cp ./GeneratedCode/SwaggerCodegen/Output.cs ./GeneratedCode/SwaggerCodegen/Net472/Output.cs
         cp ./GeneratedCode/SwaggerCodegen/Output.cs ./GeneratedCode/SwaggerCodegen/Net462/Output.cs
@@ -172,6 +194,14 @@ jobs:
 
     - name: Build .NET 7 Swagger Codegen CLI generated code
       run: dotnet build ./GeneratedCode/SwaggerCodegen/Net7/Net7.csproj
+      working-directory: test
+      
+    - name: Build .NET 8 Swagger Codegen CLI generated code
+      run: dotnet build ./GeneratedCode/SwaggerCodegen/Net8/Net8.csproj
+      working-directory: test
+      
+    - name: Build .NET 9 Swagger Codegen CLI generated code
+      run: dotnet build ./GeneratedCode/SwaggerCodegen/Net9/Net9.csproj
       working-directory: test
 
     - name: Build .NET 4.8.1 Swagger Codegen CLI generated code
@@ -204,6 +234,8 @@ jobs:
         dotnet run --project ../src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -- -v csharp autorest ./OpenApi.${{ matrix.format }} GeneratedCode ./GeneratedCode/AutoRest-${{ matrix.version }}/Output.cs --no-logging
         cp ./GeneratedCode/AutoRest-${{ matrix.version }}/Output.cs ./GeneratedCode/AutoRest-${{ matrix.version }}/Net6/Output.cs
         cp ./GeneratedCode/AutoRest-${{ matrix.version }}/Output.cs ./GeneratedCode/AutoRest-${{ matrix.version }}/Net7/Output.cs
+        cp ./GeneratedCode/AutoRest-${{ matrix.version }}/Output.cs ./GeneratedCode/AutoRest-${{ matrix.version }}/Net8/Output.cs
+        cp ./GeneratedCode/AutoRest-${{ matrix.version }}/Output.cs ./GeneratedCode/AutoRest-${{ matrix.version }}/Net9/Output.cs
         cp ./GeneratedCode/AutoRest-${{ matrix.version }}/Output.cs ./GeneratedCode/AutoRest-${{ matrix.version }}/Net48/Output.cs
         cp ./GeneratedCode/AutoRest-${{ matrix.version }}/Output.cs ./GeneratedCode/AutoRest-${{ matrix.version }}/Net472/Output.cs
         cp ./GeneratedCode/AutoRest-${{ matrix.version }}/Output.cs ./GeneratedCode/AutoRest-${{ matrix.version }}/Net462/Output.cs
@@ -219,6 +251,14 @@ jobs:
 
     - name: Build .NET 7 AutoRest generated code
       run: dotnet build ./GeneratedCode/AutoRest-${{ matrix.version }}/Net7/Net7.csproj
+      working-directory: test
+      
+    - name: Build .NET 8 AutoRest generated code
+      run: dotnet build ./GeneratedCode/AutoRest-${{ matrix.version }}/Net8/Net8.csproj
+      working-directory: test
+      
+    - name: Build .NET 9 AutoRest generated code
+      run: dotnet build ./GeneratedCode/AutoRest-${{ matrix.version }}/Net9/Net9.csproj
       working-directory: test
 
     - name: Build .NET 4.8.1 AutoRest generated code
@@ -261,6 +301,8 @@ jobs:
         dotnet run --project ../src/CLI/ApiClientCodeGen.CLI/ApiClientCodeGen.CLI.csproj -- -v csharp refitter ./OpenApi.${{ matrix.format }} GeneratedCode ./GeneratedCode/Refitter/Output.cs --no-logging
         cp ./GeneratedCode/Refitter/Output.cs ./GeneratedCode/Refitter/Net6/Output.cs
         cp ./GeneratedCode/Refitter/Output.cs ./GeneratedCode/Refitter/Net7/Output.cs
+        cp ./GeneratedCode/Refitter/Output.cs ./GeneratedCode/Refitter/Net8/Output.cs
+        cp ./GeneratedCode/Refitter/Output.cs ./GeneratedCode/Refitter/Net9/Output.cs
         cp ./GeneratedCode/Refitter/Output.cs ./GeneratedCode/Refitter/Net48/Output.cs
         cp ./GeneratedCode/Refitter/Output.cs ./GeneratedCode/Refitter/Net472/Output.cs
         cp ./GeneratedCode/Refitter/Output.cs ./GeneratedCode/Refitter/Net462/Output.cs
@@ -275,6 +317,14 @@ jobs:
 
     - name: Build .NET 7 Refitter generated code
       run: dotnet build ./GeneratedCode/Refitter/Net7/Net7.csproj
+      working-directory: test
+      
+    - name: Build .NET 8 Refitter generated code
+      run: dotnet build ./GeneratedCode/Refitter/Net8/Net8.csproj
+      working-directory: test
+      
+    - name: Build .NET 9 Refitter generated code
+      run: dotnet build ./GeneratedCode/Refitter/Net9/Net9.csproj
       working-directory: test
 
     - name: Build .NET 4.8.1 Refitter generated code

--- a/test/GeneratedCode/AutoRest-V2/Net8/Net8.csproj
+++ b/test/GeneratedCode/AutoRest-V2/Net8/Net8.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
+  </ItemGroup>
+</Project>

--- a/test/GeneratedCode/AutoRest-V2/Net8/Net8.csproj
+++ b/test/GeneratedCode/AutoRest-V2/Net8/Net8.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />

--- a/test/GeneratedCode/AutoRest-V2/Net9/Net9.csproj
+++ b/test/GeneratedCode/AutoRest-V2/Net9/Net9.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />

--- a/test/GeneratedCode/AutoRest-V2/Net9/Net9.csproj
+++ b/test/GeneratedCode/AutoRest-V2/Net9/Net9.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
+  </ItemGroup>
+</Project>

--- a/test/GeneratedCode/AutoRest-V3/Net8/Net8.csproj
+++ b/test/GeneratedCode/AutoRest-V3/Net8/Net8.csproj
@@ -1,10 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <IncludeGeneratorSharedCode>true</IncludeGeneratorSharedCode>
+    <RestoreAdditionalProjectSources>https://azuresdkartifacts.blob.core.windows.net/azure-sdk-tools/index.json</RestoreAdditionalProjectSources>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
+    <PackageReference Include="Microsoft.Azure.AutoRest.CSharp" Version="3.0.0-beta.20210218.1" PrivateAssets="All" />
+    <PackageReference Include="Azure.Core" Version="1.46.0" />
   </ItemGroup>
 </Project>

--- a/test/GeneratedCode/AutoRest-V3/Net8/Net8.csproj
+++ b/test/GeneratedCode/AutoRest-V3/Net8/Net8.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
+  </ItemGroup>
+</Project>

--- a/test/GeneratedCode/AutoRest-V3/Net9/Net9.csproj
+++ b/test/GeneratedCode/AutoRest-V3/Net9/Net9.csproj
@@ -1,10 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <IncludeGeneratorSharedCode>true</IncludeGeneratorSharedCode>
+    <RestoreAdditionalProjectSources>https://azuresdkartifacts.blob.core.windows.net/azure-sdk-tools/index.json</RestoreAdditionalProjectSources>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
+    <PackageReference Include="Microsoft.Azure.AutoRest.CSharp" Version="3.0.0-beta.20210218.1" PrivateAssets="All" />
+    <PackageReference Include="Azure.Core" Version="1.46.0" />
   </ItemGroup>
 </Project>

--- a/test/GeneratedCode/AutoRest-V3/Net9/Net9.csproj
+++ b/test/GeneratedCode/AutoRest-V3/Net9/Net9.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
+  </ItemGroup>
+</Project>

--- a/test/GeneratedCode/NSwag/Net8/Net8.csproj
+++ b/test/GeneratedCode/NSwag/Net8/Net8.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
+  </ItemGroup>
+</Project>

--- a/test/GeneratedCode/NSwag/Net9/Net9.csproj
+++ b/test/GeneratedCode/NSwag/Net9/Net9.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
+  </ItemGroup>
+</Project>

--- a/test/GeneratedCode/OpenApiGenerator/Net8/Net8.csproj
+++ b/test/GeneratedCode/OpenApiGenerator/Net8/Net8.csproj
@@ -3,8 +3,10 @@
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="5.0.1" />
+    <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/test/GeneratedCode/OpenApiGenerator/Net8/Net8.csproj
+++ b/test/GeneratedCode/OpenApiGenerator/Net8/Net8.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
+  </ItemGroup>
+</Project>

--- a/test/GeneratedCode/OpenApiGenerator/Net9/Net9.csproj
+++ b/test/GeneratedCode/OpenApiGenerator/Net9/Net9.csproj
@@ -3,8 +3,10 @@
     <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="5.0.1" />
+    <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/test/GeneratedCode/OpenApiGenerator/Net9/Net9.csproj
+++ b/test/GeneratedCode/OpenApiGenerator/Net9/Net9.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
+  </ItemGroup>
+</Project>

--- a/test/GeneratedCode/Refitter/Net8/Net8.csproj
+++ b/test/GeneratedCode/Refitter/Net8/Net8.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Refit" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />

--- a/test/GeneratedCode/Refitter/Net8/Net8.csproj
+++ b/test/GeneratedCode/Refitter/Net8/Net8.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
+  </ItemGroup>
+</Project>

--- a/test/GeneratedCode/Refitter/Net9/Net9.csproj
+++ b/test/GeneratedCode/Refitter/Net9/Net9.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Refit" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />

--- a/test/GeneratedCode/Refitter/Net9/Net9.csproj
+++ b/test/GeneratedCode/Refitter/Net9/Net9.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
+  </ItemGroup>
+</Project>

--- a/test/GeneratedCode/SwaggerCodegen/Net8/Net8.csproj
+++ b/test/GeneratedCode/SwaggerCodegen/Net8/Net8.csproj
@@ -3,7 +3,8 @@
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="JsonSubTypes" Version="1.9.0" />
+    <PackageReference Include="RestSharp" Version="105.1.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
   </ItemGroup>

--- a/test/GeneratedCode/SwaggerCodegen/Net8/Net8.csproj
+++ b/test/GeneratedCode/SwaggerCodegen/Net8/Net8.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
+  </ItemGroup>
+</Project>

--- a/test/GeneratedCode/SwaggerCodegen/Net9/Net9.csproj
+++ b/test/GeneratedCode/SwaggerCodegen/Net9/Net9.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
+  </ItemGroup>
+</Project>

--- a/test/GeneratedCode/SwaggerCodegen/Net9/Net9.csproj
+++ b/test/GeneratedCode/SwaggerCodegen/Net9/Net9.csproj
@@ -3,7 +3,8 @@
     <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="JsonSubTypes" Version="1.9.0" />
+    <PackageReference Include="RestSharp" Version="105.1.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
   </ItemGroup>

--- a/test/generated/Docs/SwaggerPetstoreClient.xml
+++ b/test/generated/Docs/SwaggerPetstoreClient.xml
@@ -1,0 +1,1159 @@
+<?xml version="1.0" encoding="utf-8"?>
+<doc>
+  <members>
+    <member name="AddPetAsync(RequestContent,ContentType,RequestContext)">
+      <example>
+This sample shows how to call AddPetAsync.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+using RequestContent content = RequestContent.Create(new
+{
+    name = "<name>",
+    photoUrls = new object[]
+    {
+        "<photoUrls>"
+    },
+});
+Response response = await client.AddPetAsync(content, new ContentType("application/json"));
+
+Console.WriteLine(response.Status);
+]]></code>
+This sample shows how to call AddPetAsync with all parameters and request content.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+using RequestContent content = RequestContent.Create(new
+{
+    id = 1234L,
+    category = new
+    {
+        id = 1234L,
+        name = "<name>",
+    },
+    name = "<name>",
+    photoUrls = new object[]
+    {
+        "<photoUrls>"
+    },
+    tags = new object[]
+    {
+        new
+        {
+            id = 1234L,
+            name = "<name>",
+        }
+    },
+    status = "available",
+});
+Response response = await client.AddPetAsync(content, new ContentType("application/json"));
+
+Console.WriteLine(response.Status);
+]]></code></example>
+    </member>
+    <member name="AddPet(RequestContent,ContentType,RequestContext)">
+      <example>
+This sample shows how to call AddPet.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+using RequestContent content = RequestContent.Create(new
+{
+    name = "<name>",
+    photoUrls = new object[]
+    {
+        "<photoUrls>"
+    },
+});
+Response response = client.AddPet(content, new ContentType("application/json"));
+
+Console.WriteLine(response.Status);
+]]></code>
+This sample shows how to call AddPet with all parameters and request content.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+using RequestContent content = RequestContent.Create(new
+{
+    id = 1234L,
+    category = new
+    {
+        id = 1234L,
+        name = "<name>",
+    },
+    name = "<name>",
+    photoUrls = new object[]
+    {
+        "<photoUrls>"
+    },
+    tags = new object[]
+    {
+        new
+        {
+            id = 1234L,
+            name = "<name>",
+        }
+    },
+    status = "available",
+});
+Response response = client.AddPet(content, new ContentType("application/json"));
+
+Console.WriteLine(response.Status);
+]]></code></example>
+    </member>
+    <member name="UpdatePetAsync(RequestContent,ContentType,RequestContext)">
+      <example>
+This sample shows how to call UpdatePetAsync.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+using RequestContent content = RequestContent.Create(new
+{
+    name = "<name>",
+    photoUrls = new object[]
+    {
+        "<photoUrls>"
+    },
+});
+Response response = await client.UpdatePetAsync(content, new ContentType("application/json"));
+
+Console.WriteLine(response.Status);
+]]></code>
+This sample shows how to call UpdatePetAsync with all parameters and request content.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+using RequestContent content = RequestContent.Create(new
+{
+    id = 1234L,
+    category = new
+    {
+        id = 1234L,
+        name = "<name>",
+    },
+    name = "<name>",
+    photoUrls = new object[]
+    {
+        "<photoUrls>"
+    },
+    tags = new object[]
+    {
+        new
+        {
+            id = 1234L,
+            name = "<name>",
+        }
+    },
+    status = "available",
+});
+Response response = await client.UpdatePetAsync(content, new ContentType("application/json"));
+
+Console.WriteLine(response.Status);
+]]></code></example>
+    </member>
+    <member name="UpdatePet(RequestContent,ContentType,RequestContext)">
+      <example>
+This sample shows how to call UpdatePet.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+using RequestContent content = RequestContent.Create(new
+{
+    name = "<name>",
+    photoUrls = new object[]
+    {
+        "<photoUrls>"
+    },
+});
+Response response = client.UpdatePet(content, new ContentType("application/json"));
+
+Console.WriteLine(response.Status);
+]]></code>
+This sample shows how to call UpdatePet with all parameters and request content.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+using RequestContent content = RequestContent.Create(new
+{
+    id = 1234L,
+    category = new
+    {
+        id = 1234L,
+        name = "<name>",
+    },
+    name = "<name>",
+    photoUrls = new object[]
+    {
+        "<photoUrls>"
+    },
+    tags = new object[]
+    {
+        new
+        {
+            id = 1234L,
+            name = "<name>",
+        }
+    },
+    status = "available",
+});
+Response response = client.UpdatePet(content, new ContentType("application/json"));
+
+Console.WriteLine(response.Status);
+]]></code></example>
+    </member>
+    <member name="FindPetsByStatusAsync(IEnumerable{string},RequestContext)">
+      <example>
+This sample shows how to call FindPetsByStatusAsync and parse the result.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = await client.FindPetsByStatusAsync(new string[] { "available" }, null);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result[0].GetProperty("name").ToString());
+Console.WriteLine(result[0].GetProperty("photoUrls")[0].ToString());
+]]></code>
+This sample shows how to call FindPetsByStatusAsync with all parameters and parse the result.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = await client.FindPetsByStatusAsync(new string[] { "available" }, null);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result[0].GetProperty("id").ToString());
+Console.WriteLine(result[0].GetProperty("category").GetProperty("id").ToString());
+Console.WriteLine(result[0].GetProperty("category").GetProperty("name").ToString());
+Console.WriteLine(result[0].GetProperty("name").ToString());
+Console.WriteLine(result[0].GetProperty("photoUrls")[0].ToString());
+Console.WriteLine(result[0].GetProperty("tags")[0].GetProperty("id").ToString());
+Console.WriteLine(result[0].GetProperty("tags")[0].GetProperty("name").ToString());
+Console.WriteLine(result[0].GetProperty("status").ToString());
+]]></code></example>
+    </member>
+    <member name="FindPetsByStatus(IEnumerable{string},RequestContext)">
+      <example>
+This sample shows how to call FindPetsByStatus and parse the result.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = client.FindPetsByStatus(new string[] { "available" }, null);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result[0].GetProperty("name").ToString());
+Console.WriteLine(result[0].GetProperty("photoUrls")[0].ToString());
+]]></code>
+This sample shows how to call FindPetsByStatus with all parameters and parse the result.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = client.FindPetsByStatus(new string[] { "available" }, null);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result[0].GetProperty("id").ToString());
+Console.WriteLine(result[0].GetProperty("category").GetProperty("id").ToString());
+Console.WriteLine(result[0].GetProperty("category").GetProperty("name").ToString());
+Console.WriteLine(result[0].GetProperty("name").ToString());
+Console.WriteLine(result[0].GetProperty("photoUrls")[0].ToString());
+Console.WriteLine(result[0].GetProperty("tags")[0].GetProperty("id").ToString());
+Console.WriteLine(result[0].GetProperty("tags")[0].GetProperty("name").ToString());
+Console.WriteLine(result[0].GetProperty("status").ToString());
+]]></code></example>
+    </member>
+    <member name="FindPetsByTagsAsync(IEnumerable{string},RequestContext)">
+      <example>
+This sample shows how to call FindPetsByTagsAsync and parse the result.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = await client.FindPetsByTagsAsync(new string[] { "<tags>" }, null);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result[0].GetProperty("name").ToString());
+Console.WriteLine(result[0].GetProperty("photoUrls")[0].ToString());
+]]></code>
+This sample shows how to call FindPetsByTagsAsync with all parameters and parse the result.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = await client.FindPetsByTagsAsync(new string[] { "<tags>" }, null);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result[0].GetProperty("id").ToString());
+Console.WriteLine(result[0].GetProperty("category").GetProperty("id").ToString());
+Console.WriteLine(result[0].GetProperty("category").GetProperty("name").ToString());
+Console.WriteLine(result[0].GetProperty("name").ToString());
+Console.WriteLine(result[0].GetProperty("photoUrls")[0].ToString());
+Console.WriteLine(result[0].GetProperty("tags")[0].GetProperty("id").ToString());
+Console.WriteLine(result[0].GetProperty("tags")[0].GetProperty("name").ToString());
+Console.WriteLine(result[0].GetProperty("status").ToString());
+]]></code></example>
+    </member>
+    <member name="FindPetsByTags(IEnumerable{string},RequestContext)">
+      <example>
+This sample shows how to call FindPetsByTags and parse the result.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = client.FindPetsByTags(new string[] { "<tags>" }, null);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result[0].GetProperty("name").ToString());
+Console.WriteLine(result[0].GetProperty("photoUrls")[0].ToString());
+]]></code>
+This sample shows how to call FindPetsByTags with all parameters and parse the result.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = client.FindPetsByTags(new string[] { "<tags>" }, null);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result[0].GetProperty("id").ToString());
+Console.WriteLine(result[0].GetProperty("category").GetProperty("id").ToString());
+Console.WriteLine(result[0].GetProperty("category").GetProperty("name").ToString());
+Console.WriteLine(result[0].GetProperty("name").ToString());
+Console.WriteLine(result[0].GetProperty("photoUrls")[0].ToString());
+Console.WriteLine(result[0].GetProperty("tags")[0].GetProperty("id").ToString());
+Console.WriteLine(result[0].GetProperty("tags")[0].GetProperty("name").ToString());
+Console.WriteLine(result[0].GetProperty("status").ToString());
+]]></code></example>
+    </member>
+    <member name="GetPetByIdAsync(long,RequestContext)">
+      <example>
+This sample shows how to call GetPetByIdAsync and parse the result.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = await client.GetPetByIdAsync(1234L, null);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result.GetProperty("name").ToString());
+Console.WriteLine(result.GetProperty("photoUrls")[0].ToString());
+]]></code>
+This sample shows how to call GetPetByIdAsync with all parameters and parse the result.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = await client.GetPetByIdAsync(1234L, null);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result.GetProperty("id").ToString());
+Console.WriteLine(result.GetProperty("category").GetProperty("id").ToString());
+Console.WriteLine(result.GetProperty("category").GetProperty("name").ToString());
+Console.WriteLine(result.GetProperty("name").ToString());
+Console.WriteLine(result.GetProperty("photoUrls")[0].ToString());
+Console.WriteLine(result.GetProperty("tags")[0].GetProperty("id").ToString());
+Console.WriteLine(result.GetProperty("tags")[0].GetProperty("name").ToString());
+Console.WriteLine(result.GetProperty("status").ToString());
+]]></code></example>
+    </member>
+    <member name="GetPetById(long,RequestContext)">
+      <example>
+This sample shows how to call GetPetById and parse the result.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = client.GetPetById(1234L, null);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result.GetProperty("name").ToString());
+Console.WriteLine(result.GetProperty("photoUrls")[0].ToString());
+]]></code>
+This sample shows how to call GetPetById with all parameters and parse the result.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = client.GetPetById(1234L, null);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result.GetProperty("id").ToString());
+Console.WriteLine(result.GetProperty("category").GetProperty("id").ToString());
+Console.WriteLine(result.GetProperty("category").GetProperty("name").ToString());
+Console.WriteLine(result.GetProperty("name").ToString());
+Console.WriteLine(result.GetProperty("photoUrls")[0].ToString());
+Console.WriteLine(result.GetProperty("tags")[0].GetProperty("id").ToString());
+Console.WriteLine(result.GetProperty("tags")[0].GetProperty("name").ToString());
+Console.WriteLine(result.GetProperty("status").ToString());
+]]></code></example>
+    </member>
+    <member name="UpdatePetWithFormAsync(long,RequestContent,RequestContext)">
+      <example>
+This sample shows how to call UpdatePetWithFormAsync.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+using RequestContent content = null;
+Response response = await client.UpdatePetWithFormAsync(1234L, content);
+
+Console.WriteLine(response.Status);
+]]></code>
+This sample shows how to call UpdatePetWithFormAsync with all parameters and request content.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+using RequestContent content = RequestContent.Create("<name>");
+Response response = await client.UpdatePetWithFormAsync(1234L, content);
+
+Console.WriteLine(response.Status);
+]]></code></example>
+    </member>
+    <member name="UpdatePetWithForm(long,RequestContent,RequestContext)">
+      <example>
+This sample shows how to call UpdatePetWithForm.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+using RequestContent content = null;
+Response response = client.UpdatePetWithForm(1234L, content);
+
+Console.WriteLine(response.Status);
+]]></code>
+This sample shows how to call UpdatePetWithForm with all parameters and request content.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+using RequestContent content = RequestContent.Create("<name>");
+Response response = client.UpdatePetWithForm(1234L, content);
+
+Console.WriteLine(response.Status);
+]]></code></example>
+    </member>
+    <member name="DeletePetAsync(long,string,RequestContext)">
+      <example>
+This sample shows how to call DeletePetAsync.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = await client.DeletePetAsync(1234L);
+
+Console.WriteLine(response.Status);
+]]></code>
+This sample shows how to call DeletePetAsync with all parameters.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = await client.DeletePetAsync(1234L, apiKey: "<apiKey>");
+
+Console.WriteLine(response.Status);
+]]></code></example>
+    </member>
+    <member name="DeletePet(long,string,RequestContext)">
+      <example>
+This sample shows how to call DeletePet.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = client.DeletePet(1234L);
+
+Console.WriteLine(response.Status);
+]]></code>
+This sample shows how to call DeletePet with all parameters.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = client.DeletePet(1234L, apiKey: "<apiKey>");
+
+Console.WriteLine(response.Status);
+]]></code></example>
+    </member>
+    <member name="UploadFileAsync(long,RequestContent,string,RequestContext)">
+      <example>
+This sample shows how to call UploadFileAsync and parse the result.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+using RequestContent content = null;
+Response response = await client.UploadFileAsync(1234L, content, "multipart/form-data");
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result.ToString());
+]]></code>
+This sample shows how to call UploadFileAsync with all parameters and request content and parse the result.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+using RequestContent content = RequestContent.Create("<additionalMetadata>");
+Response response = await client.UploadFileAsync(1234L, content, "multipart/form-data");
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result.GetProperty("code").ToString());
+Console.WriteLine(result.GetProperty("type").ToString());
+Console.WriteLine(result.GetProperty("message").ToString());
+]]></code></example>
+    </member>
+    <member name="UploadFile(long,RequestContent,string,RequestContext)">
+      <example>
+This sample shows how to call UploadFile and parse the result.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+using RequestContent content = null;
+Response response = client.UploadFile(1234L, content, "multipart/form-data");
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result.ToString());
+]]></code>
+This sample shows how to call UploadFile with all parameters and request content and parse the result.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+using RequestContent content = RequestContent.Create("<additionalMetadata>");
+Response response = client.UploadFile(1234L, content, "multipart/form-data");
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result.GetProperty("code").ToString());
+Console.WriteLine(result.GetProperty("type").ToString());
+Console.WriteLine(result.GetProperty("message").ToString());
+]]></code></example>
+    </member>
+    <member name="GetInventoryAsync(RequestContext)">
+      <example>
+This sample shows how to call GetInventoryAsync and parse the result.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = await client.GetInventoryAsync(null);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result.GetProperty("<key>").ToString());
+]]></code>
+This sample shows how to call GetInventoryAsync with all parameters and parse the result.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = await client.GetInventoryAsync(null);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result.GetProperty("<key>").ToString());
+]]></code></example>
+    </member>
+    <member name="GetInventory(RequestContext)">
+      <example>
+This sample shows how to call GetInventory and parse the result.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = client.GetInventory(null);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result.GetProperty("<key>").ToString());
+]]></code>
+This sample shows how to call GetInventory with all parameters and parse the result.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = client.GetInventory(null);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result.GetProperty("<key>").ToString());
+]]></code></example>
+    </member>
+    <member name="PlaceOrderAsync(RequestContent,RequestContext)">
+      <example>
+This sample shows how to call PlaceOrderAsync and parse the result.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+using RequestContent content = RequestContent.Create(new object());
+Response response = await client.PlaceOrderAsync(content);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result.ToString());
+]]></code>
+This sample shows how to call PlaceOrderAsync with all request content and parse the result.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+using RequestContent content = RequestContent.Create(new
+{
+    id = 1234L,
+    petId = 1234L,
+    quantity = 1234,
+    shipDate = "2022-05-10T18:57:31.2311892Z",
+    status = "placed",
+    complete = true,
+});
+Response response = await client.PlaceOrderAsync(content);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result.GetProperty("id").ToString());
+Console.WriteLine(result.GetProperty("petId").ToString());
+Console.WriteLine(result.GetProperty("quantity").ToString());
+Console.WriteLine(result.GetProperty("shipDate").ToString());
+Console.WriteLine(result.GetProperty("status").ToString());
+Console.WriteLine(result.GetProperty("complete").ToString());
+]]></code></example>
+    </member>
+    <member name="PlaceOrder(RequestContent,RequestContext)">
+      <example>
+This sample shows how to call PlaceOrder and parse the result.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+using RequestContent content = RequestContent.Create(new object());
+Response response = client.PlaceOrder(content);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result.ToString());
+]]></code>
+This sample shows how to call PlaceOrder with all request content and parse the result.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+using RequestContent content = RequestContent.Create(new
+{
+    id = 1234L,
+    petId = 1234L,
+    quantity = 1234,
+    shipDate = "2022-05-10T18:57:31.2311892Z",
+    status = "placed",
+    complete = true,
+});
+Response response = client.PlaceOrder(content);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result.GetProperty("id").ToString());
+Console.WriteLine(result.GetProperty("petId").ToString());
+Console.WriteLine(result.GetProperty("quantity").ToString());
+Console.WriteLine(result.GetProperty("shipDate").ToString());
+Console.WriteLine(result.GetProperty("status").ToString());
+Console.WriteLine(result.GetProperty("complete").ToString());
+]]></code></example>
+    </member>
+    <member name="GetOrderByIdAsync(long,RequestContext)">
+      <example>
+This sample shows how to call GetOrderByIdAsync and parse the result.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = await client.GetOrderByIdAsync(1234L, null);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result.ToString());
+]]></code>
+This sample shows how to call GetOrderByIdAsync with all parameters and parse the result.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = await client.GetOrderByIdAsync(1234L, null);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result.GetProperty("id").ToString());
+Console.WriteLine(result.GetProperty("petId").ToString());
+Console.WriteLine(result.GetProperty("quantity").ToString());
+Console.WriteLine(result.GetProperty("shipDate").ToString());
+Console.WriteLine(result.GetProperty("status").ToString());
+Console.WriteLine(result.GetProperty("complete").ToString());
+]]></code></example>
+    </member>
+    <member name="GetOrderById(long,RequestContext)">
+      <example>
+This sample shows how to call GetOrderById and parse the result.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = client.GetOrderById(1234L, null);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result.ToString());
+]]></code>
+This sample shows how to call GetOrderById with all parameters and parse the result.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = client.GetOrderById(1234L, null);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result.GetProperty("id").ToString());
+Console.WriteLine(result.GetProperty("petId").ToString());
+Console.WriteLine(result.GetProperty("quantity").ToString());
+Console.WriteLine(result.GetProperty("shipDate").ToString());
+Console.WriteLine(result.GetProperty("status").ToString());
+Console.WriteLine(result.GetProperty("complete").ToString());
+]]></code></example>
+    </member>
+    <member name="DeleteOrderAsync(long,RequestContext)">
+      <example>
+This sample shows how to call DeleteOrderAsync.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = await client.DeleteOrderAsync(1234L);
+
+Console.WriteLine(response.Status);
+]]></code>
+This sample shows how to call DeleteOrderAsync with all parameters.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = await client.DeleteOrderAsync(1234L);
+
+Console.WriteLine(response.Status);
+]]></code></example>
+    </member>
+    <member name="DeleteOrder(long,RequestContext)">
+      <example>
+This sample shows how to call DeleteOrder.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = client.DeleteOrder(1234L);
+
+Console.WriteLine(response.Status);
+]]></code>
+This sample shows how to call DeleteOrder with all parameters.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = client.DeleteOrder(1234L);
+
+Console.WriteLine(response.Status);
+]]></code></example>
+    </member>
+    <member name="CreateUserAsync(RequestContent,RequestContext)">
+      <example>
+This sample shows how to call CreateUserAsync.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+using RequestContent content = RequestContent.Create(new object());
+Response response = await client.CreateUserAsync(content);
+
+Console.WriteLine(response.Status);
+]]></code>
+This sample shows how to call CreateUserAsync with all request content.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+using RequestContent content = RequestContent.Create(new
+{
+    id = 1234L,
+    username = "<username>",
+    firstName = "<firstName>",
+    lastName = "<lastName>",
+    email = "<email>",
+    password = "<password>",
+    phone = "<phone>",
+    userStatus = 1234,
+});
+Response response = await client.CreateUserAsync(content);
+
+Console.WriteLine(response.Status);
+]]></code></example>
+    </member>
+    <member name="CreateUser(RequestContent,RequestContext)">
+      <example>
+This sample shows how to call CreateUser.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+using RequestContent content = RequestContent.Create(new object());
+Response response = client.CreateUser(content);
+
+Console.WriteLine(response.Status);
+]]></code>
+This sample shows how to call CreateUser with all request content.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+using RequestContent content = RequestContent.Create(new
+{
+    id = 1234L,
+    username = "<username>",
+    firstName = "<firstName>",
+    lastName = "<lastName>",
+    email = "<email>",
+    password = "<password>",
+    phone = "<phone>",
+    userStatus = 1234,
+});
+Response response = client.CreateUser(content);
+
+Console.WriteLine(response.Status);
+]]></code></example>
+    </member>
+    <member name="CreateUsersWithArrayInputAsync(RequestContent,RequestContext)">
+      <example>
+This sample shows how to call CreateUsersWithArrayInputAsync.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+using RequestContent content = RequestContent.Create(new object[]
+{
+    new object()
+});
+Response response = await client.CreateUsersWithArrayInputAsync(content);
+
+Console.WriteLine(response.Status);
+]]></code>
+This sample shows how to call CreateUsersWithArrayInputAsync with all request content.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+using RequestContent content = RequestContent.Create(new object[]
+{
+    new
+    {
+        id = 1234L,
+        username = "<username>",
+        firstName = "<firstName>",
+        lastName = "<lastName>",
+        email = "<email>",
+        password = "<password>",
+        phone = "<phone>",
+        userStatus = 1234,
+    }
+});
+Response response = await client.CreateUsersWithArrayInputAsync(content);
+
+Console.WriteLine(response.Status);
+]]></code></example>
+    </member>
+    <member name="CreateUsersWithArrayInput(RequestContent,RequestContext)">
+      <example>
+This sample shows how to call CreateUsersWithArrayInput.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+using RequestContent content = RequestContent.Create(new object[]
+{
+    new object()
+});
+Response response = client.CreateUsersWithArrayInput(content);
+
+Console.WriteLine(response.Status);
+]]></code>
+This sample shows how to call CreateUsersWithArrayInput with all request content.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+using RequestContent content = RequestContent.Create(new object[]
+{
+    new
+    {
+        id = 1234L,
+        username = "<username>",
+        firstName = "<firstName>",
+        lastName = "<lastName>",
+        email = "<email>",
+        password = "<password>",
+        phone = "<phone>",
+        userStatus = 1234,
+    }
+});
+Response response = client.CreateUsersWithArrayInput(content);
+
+Console.WriteLine(response.Status);
+]]></code></example>
+    </member>
+    <member name="CreateUsersWithListInputAsync(RequestContent,RequestContext)">
+      <example>
+This sample shows how to call CreateUsersWithListInputAsync.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+using RequestContent content = RequestContent.Create(new object[]
+{
+    new object()
+});
+Response response = await client.CreateUsersWithListInputAsync(content);
+
+Console.WriteLine(response.Status);
+]]></code>
+This sample shows how to call CreateUsersWithListInputAsync with all request content.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+using RequestContent content = RequestContent.Create(new object[]
+{
+    new
+    {
+        id = 1234L,
+        username = "<username>",
+        firstName = "<firstName>",
+        lastName = "<lastName>",
+        email = "<email>",
+        password = "<password>",
+        phone = "<phone>",
+        userStatus = 1234,
+    }
+});
+Response response = await client.CreateUsersWithListInputAsync(content);
+
+Console.WriteLine(response.Status);
+]]></code></example>
+    </member>
+    <member name="CreateUsersWithListInput(RequestContent,RequestContext)">
+      <example>
+This sample shows how to call CreateUsersWithListInput.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+using RequestContent content = RequestContent.Create(new object[]
+{
+    new object()
+});
+Response response = client.CreateUsersWithListInput(content);
+
+Console.WriteLine(response.Status);
+]]></code>
+This sample shows how to call CreateUsersWithListInput with all request content.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+using RequestContent content = RequestContent.Create(new object[]
+{
+    new
+    {
+        id = 1234L,
+        username = "<username>",
+        firstName = "<firstName>",
+        lastName = "<lastName>",
+        email = "<email>",
+        password = "<password>",
+        phone = "<phone>",
+        userStatus = 1234,
+    }
+});
+Response response = client.CreateUsersWithListInput(content);
+
+Console.WriteLine(response.Status);
+]]></code></example>
+    </member>
+    <member name="LoginUserAsync(string,string,RequestContext)">
+      <example>
+This sample shows how to call LoginUserAsync and parse the result.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = await client.LoginUserAsync("<username>", "<password>", null);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result.ToString());
+]]></code>
+This sample shows how to call LoginUserAsync with all parameters and parse the result.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = await client.LoginUserAsync("<username>", "<password>", null);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result.ToString());
+]]></code></example>
+    </member>
+    <member name="LoginUser(string,string,RequestContext)">
+      <example>
+This sample shows how to call LoginUser and parse the result.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = client.LoginUser("<username>", "<password>", null);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result.ToString());
+]]></code>
+This sample shows how to call LoginUser with all parameters and parse the result.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = client.LoginUser("<username>", "<password>", null);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result.ToString());
+]]></code></example>
+    </member>
+    <member name="LogoutUserAsync(RequestContext)">
+      <example>
+This sample shows how to call LogoutUserAsync.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = await client.LogoutUserAsync();
+
+Console.WriteLine(response.Status);
+]]></code>
+This sample shows how to call LogoutUserAsync with all request content.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = await client.LogoutUserAsync();
+
+Console.WriteLine(response.Status);
+]]></code></example>
+    </member>
+    <member name="LogoutUser(RequestContext)">
+      <example>
+This sample shows how to call LogoutUser.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = client.LogoutUser();
+
+Console.WriteLine(response.Status);
+]]></code>
+This sample shows how to call LogoutUser with all request content.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = client.LogoutUser();
+
+Console.WriteLine(response.Status);
+]]></code></example>
+    </member>
+    <member name="GetUserByNameAsync(string,RequestContext)">
+      <example>
+This sample shows how to call GetUserByNameAsync and parse the result.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = await client.GetUserByNameAsync("<username>", null);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result.ToString());
+]]></code>
+This sample shows how to call GetUserByNameAsync with all parameters and parse the result.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = await client.GetUserByNameAsync("<username>", null);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result.GetProperty("id").ToString());
+Console.WriteLine(result.GetProperty("username").ToString());
+Console.WriteLine(result.GetProperty("firstName").ToString());
+Console.WriteLine(result.GetProperty("lastName").ToString());
+Console.WriteLine(result.GetProperty("email").ToString());
+Console.WriteLine(result.GetProperty("password").ToString());
+Console.WriteLine(result.GetProperty("phone").ToString());
+Console.WriteLine(result.GetProperty("userStatus").ToString());
+]]></code></example>
+    </member>
+    <member name="GetUserByName(string,RequestContext)">
+      <example>
+This sample shows how to call GetUserByName and parse the result.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = client.GetUserByName("<username>", null);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result.ToString());
+]]></code>
+This sample shows how to call GetUserByName with all parameters and parse the result.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = client.GetUserByName("<username>", null);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result.GetProperty("id").ToString());
+Console.WriteLine(result.GetProperty("username").ToString());
+Console.WriteLine(result.GetProperty("firstName").ToString());
+Console.WriteLine(result.GetProperty("lastName").ToString());
+Console.WriteLine(result.GetProperty("email").ToString());
+Console.WriteLine(result.GetProperty("password").ToString());
+Console.WriteLine(result.GetProperty("phone").ToString());
+Console.WriteLine(result.GetProperty("userStatus").ToString());
+]]></code></example>
+    </member>
+    <member name="UpdateUserAsync(string,RequestContent,RequestContext)">
+      <example>
+This sample shows how to call UpdateUserAsync.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+using RequestContent content = RequestContent.Create(new object());
+Response response = await client.UpdateUserAsync("<username>", content);
+
+Console.WriteLine(response.Status);
+]]></code>
+This sample shows how to call UpdateUserAsync with all parameters and request content.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+using RequestContent content = RequestContent.Create(new
+{
+    id = 1234L,
+    username = "<username>",
+    firstName = "<firstName>",
+    lastName = "<lastName>",
+    email = "<email>",
+    password = "<password>",
+    phone = "<phone>",
+    userStatus = 1234,
+});
+Response response = await client.UpdateUserAsync("<username>", content);
+
+Console.WriteLine(response.Status);
+]]></code></example>
+    </member>
+    <member name="UpdateUser(string,RequestContent,RequestContext)">
+      <example>
+This sample shows how to call UpdateUser.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+using RequestContent content = RequestContent.Create(new object());
+Response response = client.UpdateUser("<username>", content);
+
+Console.WriteLine(response.Status);
+]]></code>
+This sample shows how to call UpdateUser with all parameters and request content.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+using RequestContent content = RequestContent.Create(new
+{
+    id = 1234L,
+    username = "<username>",
+    firstName = "<firstName>",
+    lastName = "<lastName>",
+    email = "<email>",
+    password = "<password>",
+    phone = "<phone>",
+    userStatus = 1234,
+});
+Response response = client.UpdateUser("<username>", content);
+
+Console.WriteLine(response.Status);
+]]></code></example>
+    </member>
+    <member name="DeleteUserAsync(string,RequestContext)">
+      <example>
+This sample shows how to call DeleteUserAsync.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = await client.DeleteUserAsync("<username>");
+
+Console.WriteLine(response.Status);
+]]></code>
+This sample shows how to call DeleteUserAsync with all parameters.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = await client.DeleteUserAsync("<username>");
+
+Console.WriteLine(response.Status);
+]]></code></example>
+    </member>
+    <member name="DeleteUser(string,RequestContext)">
+      <example>
+This sample shows how to call DeleteUser.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = client.DeleteUser("<username>");
+
+Console.WriteLine(response.Status);
+]]></code>
+This sample shows how to call DeleteUser with all parameters.
+<code><![CDATA[
+SwaggerPetstoreClient client = new SwaggerPetstoreClient();
+
+Response response = client.DeleteUser("<username>");
+
+Console.WriteLine(response.Status);
+]]></code></example>
+    </member>
+  </members>
+</doc>

--- a/test/utilities.ps1
+++ b/test/utilities.ps1
@@ -17,6 +17,8 @@ function Install-DotNetRuntimes {
     ./dotnet-install.ps1 -Version 5.0.100
     ./dotnet-install.ps1 -Version 6.0.100
     ./dotnet-install.ps1 -Version 7.0.100
+    ./dotnet-install.ps1 -Version 8.0.100
+    ./dotnet-install.ps1 -Version 9.0.100-preview.1.24101.2
 }
 
 function Install-Rapicgen {
@@ -89,6 +91,8 @@ function Build-GeneratedCode {
                 $argumentsList += "build ./GeneratedCode/$_/NetStandard21/NetStandard21.csproj"
                 $argumentsList += "build ./GeneratedCode/$_/Net6/Net6.csproj"
                 $argumentsList += "build ./GeneratedCode/$_/Net7/Net7.csproj"
+                $argumentsList += "build ./GeneratedCode/$_/Net8/Net8.csproj"
+                $argumentsList += "build ./GeneratedCode/$_/Net9/Net9.csproj"
                 $argumentsList += "build ./GeneratedCode/$_/Net48/Net48.csproj"
                 $argumentsList += "build ./GeneratedCode/$_/Net481/Net481.csproj"
                 $argumentsList += "build ./GeneratedCode/$_/Net472/Net472.csproj"
@@ -103,13 +107,15 @@ function Build-GeneratedCode {
                 "build ./GeneratedCode/$ToolName/NetStandard21/NetStandard21.csproj",
                 "build ./GeneratedCode/$ToolName/Net6/Net6.csproj",
                 "build ./GeneratedCode/$ToolName/Net7/Net7.csproj",
+                "build ./GeneratedCode/$ToolName/Net8/Net8.csproj",
+                "build ./GeneratedCode/$ToolName/Net9/Net9.csproj",
                 "build ./GeneratedCode/$ToolName/Net48/Net48.csproj",
                 "build ./GeneratedCode/$ToolName/Net481/Net481.csproj",
                 "build ./GeneratedCode/$ToolName/Net472/Net472.csproj"
             )
 
-            if ($_ -notcontains "AutoRest-V3") {
-                $argumentsList += "build ./GeneratedCode/$_/Net462/Net462.csproj"
+            if ($ToolName -notcontains "AutoRest-V3") {
+                $argumentsList += "build ./GeneratedCode/$ToolName/Net462/Net462.csproj"
             }
         }
         
@@ -128,6 +134,10 @@ function Build-GeneratedCode {
                 Write-Host "`r`nBuilding $_`r`n"
                 dotnet build ./GeneratedCode/$_/NetStandard20/NetStandard20.csproj; ThrowOnNativeFailure
                 dotnet build ./GeneratedCode/$_/NetStandard21/NetStandard21.csproj; ThrowOnNativeFailure
+                dotnet build ./GeneratedCode/$_/Net6/Net6.csproj; ThrowOnNativeFailure
+                dotnet build ./GeneratedCode/$_/Net7/Net7.csproj; ThrowOnNativeFailure
+                dotnet build ./GeneratedCode/$_/Net8/Net8.csproj; ThrowOnNativeFailure
+                dotnet build ./GeneratedCode/$_/Net9/Net9.csproj; ThrowOnNativeFailure
                 dotnet build ./GeneratedCode/$_/Net48/Net48.csproj; ThrowOnNativeFailure
                 dotnet build ./GeneratedCode/$_/Net481/Net481.csproj; ThrowOnNativeFailure
                 dotnet build ./GeneratedCode/$_/Net472/Net472.csproj; ThrowOnNativeFailure
@@ -141,11 +151,15 @@ function Build-GeneratedCode {
             Write-Host "`r`nBuilding $ToolName`r`n"
             dotnet build ./GeneratedCode/$ToolName/NetStandard20/NetStandard20.csproj; ThrowOnNativeFailure
             dotnet build ./GeneratedCode/$ToolName/NetStandard21/NetStandard21.csproj; ThrowOnNativeFailure
+            dotnet build ./GeneratedCode/$ToolName/Net6/Net6.csproj; ThrowOnNativeFailure
+            dotnet build ./GeneratedCode/$ToolName/Net7/Net7.csproj; ThrowOnNativeFailure
+            dotnet build ./GeneratedCode/$ToolName/Net8/Net8.csproj; ThrowOnNativeFailure
+            dotnet build ./GeneratedCode/$ToolName/Net9/Net9.csproj; ThrowOnNativeFailure
             dotnet build ./GeneratedCode/$ToolName/Net48/Net48.csproj; ThrowOnNativeFailure
             dotnet build ./GeneratedCode/$ToolName/Net481/Net481.csproj; ThrowOnNativeFailure
             dotnet build ./GeneratedCode/$ToolName/Net472/Net472.csproj; ThrowOnNativeFailure
 
-            if ($_ -notcontains "AutoRest-V3") {
+            if ($ToolName -notcontains "AutoRest-V3") {
                 dotnet build ./GeneratedCode/$ToolName/Net462/Net462.csproj; ThrowOnNativeFailure
                 dotnet build ./GeneratedCode/$ToolName/Net452/Net452.csproj; ThrowOnNativeFailure
             }
@@ -227,6 +241,8 @@ function Generate-Code {
 
     Copy-Item "GeneratedCode/$ToolName/Output.cs" "./GeneratedCode/$ToolName/Net7/Output.cs" -Force
     Copy-Item "GeneratedCode/$ToolName/Output.cs" "./GeneratedCode/$ToolName/Net6/Output.cs" -Force
+    Copy-Item "GeneratedCode/$ToolName/Output.cs" "./GeneratedCode/$ToolName/Net8/Output.cs" -Force
+    Copy-Item "GeneratedCode/$ToolName/Output.cs" "./GeneratedCode/$ToolName/Net9/Output.cs" -Force
     Copy-Item "GeneratedCode/$ToolName/Output.cs" "./GeneratedCode/$ToolName/Net48/Output.cs" -Force
     Copy-Item "GeneratedCode/$ToolName/Output.cs" "./GeneratedCode/$ToolName/Net481/Output.cs" -Force
     Copy-Item "GeneratedCode/$ToolName/Output.cs" "./GeneratedCode/$ToolName/Net472/Output.cs" -Force
@@ -287,6 +303,8 @@ function Generate-CodeParallel {
         if (Test-Path "GeneratedCode/$_/Output.cs" -PathType Leaf) {
             Copy-Item "GeneratedCode/$_/Output.cs" "./GeneratedCode/$_/Net7/Output.cs" -Force
             Copy-Item "GeneratedCode/$_/Output.cs" "./GeneratedCode/$_/Net6/Output.cs" -Force
+            Copy-Item "GeneratedCode/$_/Output.cs" "./GeneratedCode/$_/Net8/Output.cs" -Force
+            Copy-Item "GeneratedCode/$_/Output.cs" "./GeneratedCode/$_/Net9/Output.cs" -Force
             Copy-Item "GeneratedCode/$_/Output.cs" "./GeneratedCode/$_/Net48/Output.cs" -Force
             Copy-Item "GeneratedCode/$_/Output.cs" "./GeneratedCode/$_/Net481/Output.cs" -Force
             Copy-Item "GeneratedCode/$_/Output.cs" "./GeneratedCode/$_/Net472/Output.cs" -Force


### PR DESCRIPTION
This pull request adds support for .NET 8 and .NET 9 across multiple workflows and generated code projects. It updates the regression tests and smoke tests workflows to include these new versions and adds corresponding project files for .NET 8 and .NET 9 in the generated code directories.

### Workflow Updates for .NET 8 and .NET 9:

* `.github/workflows/regression-tests.yml`:
  - Added .NET 8 (`net8.0`) and .NET 9 (`net9.0`) to the matrix versions and ensured generated code is built and tested for these frameworks. [[1]](diffhunk://#diff-f0de00012d74c09571bcabcb38ab9ba495177a8e76c00e5ab27cc887118e9b79R60) [[2]](diffhunk://#diff-f0de00012d74c09571bcabcb38ab9ba495177a8e76c00e5ab27cc887118e9b79R89-R96) [[3]](diffhunk://#diff-f0de00012d74c09571bcabcb38ab9ba495177a8e76c00e5ab27cc887118e9b79R145-R152) [[4]](diffhunk://#diff-f0de00012d74c09571bcabcb38ab9ba495177a8e76c00e5ab27cc887118e9b79R201-R208) [[5]](diffhunk://#diff-f0de00012d74c09571bcabcb38ab9ba495177a8e76c00e5ab27cc887118e9b79R258-R265) [[6]](diffhunk://#diff-f0de00012d74c09571bcabcb38ab9ba495177a8e76c00e5ab27cc887118e9b79R323-R330)
  - Updated all code generation steps (NSwag, OpenAPI Generator, Swagger Codegen, AutoRest, and Refitter) to include copying output for .NET 8 and .NET 9. [[1]](diffhunk://#diff-f0de00012d74c09571bcabcb38ab9ba495177a8e76c00e5ab27cc887118e9b79R71-R72) [[2]](diffhunk://#diff-f0de00012d74c09571bcabcb38ab9ba495177a8e76c00e5ab27cc887118e9b79R127-R128) [[3]](diffhunk://#diff-f0de00012d74c09571bcabcb38ab9ba495177a8e76c00e5ab27cc887118e9b79R183-R184) [[4]](diffhunk://#diff-f0de00012d74c09571bcabcb38ab9ba495177a8e76c00e5ab27cc887118e9b79R239-R240) [[5]](diffhunk://#diff-f0de00012d74c09571bcabcb38ab9ba495177a8e76c00e5ab27cc887118e9b79R305-R306)

* `.github/workflows/smoke-tests.yml`:
  - Added build steps for .NET 8 and .NET 9 generated code across all tools (NSwag, OpenAPI Generator, Swagger Codegen, AutoRest, and Refitter). [[1]](diffhunk://#diff-0482f7923f54602462105f3b58b0046b0406cea61aea098d17878f0e14bc6921R87-R94) [[2]](diffhunk://#diff-0482f7923f54602462105f3b58b0046b0406cea61aea098d17878f0e14bc6921R143-R150) [[3]](diffhunk://#diff-0482f7923f54602462105f3b58b0046b0406cea61aea098d17878f0e14bc6921R199-R206) [[4]](diffhunk://#diff-0482f7923f54602462105f3b58b0046b0406cea61aea098d17878f0e14bc6921R256-R263) [[5]](diffhunk://#diff-0482f7923f54602462105f3b58b0046b0406cea61aea098d17878f0e14bc6921R322-R329)
  - Updated code generation steps to include .NET 8 and .NET 9 output. [[1]](diffhunk://#diff-0482f7923f54602462105f3b58b0046b0406cea61aea098d17878f0e14bc6921R69-R70) [[2]](diffhunk://#diff-0482f7923f54602462105f3b58b0046b0406cea61aea098d17878f0e14bc6921R125-R126) [[3]](diffhunk://#diff-0482f7923f54602462105f3b58b0046b0406cea61aea098d17878f0e14bc6921R181-R182) [[4]](diffhunk://#diff-0482f7923f54602462105f3b58b0046b0406cea61aea098d17878f0e14bc6921R237-R238) [[5]](diffhunk://#diff-0482f7923f54602462105f3b58b0046b0406cea61aea098d17878f0e14bc6921R304-R305)

### New Project Files for .NET 8:

* Added `Net8.csproj` files for AutoRest, NSwag, OpenAPI Generator, Swagger Codegen, and Refitter in their respective directories. These files include the necessary dependencies and target framework set to `net8.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for .NET 8 and .NET 9 in all code generation, build, regression, and smoke test workflows.
  - Introduced new project files targeting .NET 8 and .NET 9 for all supported code generation tools.
- **Chores**
  - Updated scripts and workflows to install and build against .NET 8 and .NET 9 runtimes.
  - Ensured generated code is tested and built for .NET 8 and .NET 9 across all tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->