### PR TITLE
Group C# Code Generators in Visual Studio Code

### DIFF
--- a/src/VSCode/package.json
+++ b/src/VSCode/package.json
@@ -28,27 +28,27 @@
     "commands": [
       {
         "command": "restApiClientCodeGenerator.nswag",
-        "title": "Generate with NSwag (v14.4.0)"
+        "title": "Generate C# with NSwag (v14.4.0)"
       },
       {
         "command": "restApiClientCodeGenerator.refitter",
-        "title": "Generate with Refitter (v1.5.5)"
+        "title": "Generate C# with Refitter (v1.5.5)"
       },
       {
         "command": "restApiClientCodeGenerator.openapi",
-        "title": "Generate with OpenAPI Generator (v7.13.0)"
+        "title": "Generate C# with OpenAPI Generator (v7.13.0)"
       },
       {
         "command": "restApiClientCodeGenerator.kiota",
-        "title": "Generate with Microsoft Kiota (v1.26.1)"
+        "title": "Generate C# with Microsoft Kiota (v1.26.1)"
       },
       {
         "command": "restApiClientCodeGenerator.swagger",
-        "title": "Generate with Swagger (v3.0.34 - Outdated)"
+        "title": "Generate C# with Swagger (v3.0.34 - Outdated)"
       },
       {
         "command": "restApiClientCodeGenerator.autoRest",
-        "title": "Generate with AutoRest (v3.0.0-beta - Outdated)"
+        "title": "Generate C# with AutoRest (v3.0.0-beta - Outdated)"
       }
     ],
     "menus": {

--- a/src/VSCode/package.json
+++ b/src/VSCode/package.json
@@ -50,7 +50,8 @@
         "command": "restApiClientCodeGenerator.autoRest",
         "title": "Generate with AutoRest (v3.0.0-beta - Outdated)"
       }
-    ],    "menus": {
+    ],
+    "menus": {
       "explorer/context": [
         {
           "submenu": "restApiClientCodeGenerator.submenu",
@@ -59,6 +60,12 @@
         }
       ],
       "restApiClientCodeGenerator.submenu": [
+        {
+          "submenu": "restApiClientCodeGenerator.csharpSubmenu",
+          "group": "1_languages@1"
+        }
+      ],
+      "restApiClientCodeGenerator.csharpSubmenu": [
         {
           "command": "restApiClientCodeGenerator.nswag",
           "group": "1_generators@1"
@@ -89,6 +96,10 @@
       {
         "id": "restApiClientCodeGenerator.submenu",
         "label": "REST API Client Generator"
+      },
+      {
+        "id": "restApiClientCodeGenerator.csharpSubmenu",
+        "label": "C#"
       }
     ],
     "configuration": {


### PR DESCRIPTION
This pull request updates the `src/VSCode/package.json` file to improve the organization of commands and menus for generating REST API client code. It introduces clearer labeling for C# generation commands and restructures the menu hierarchy to enhance usability.

### Improvements to command labeling:
* Updated the titles of all REST API client generation commands to explicitly mention "C#" (e.g., "Generate C# with NSwag") for clarity.

### Menu restructuring:
* Added a new submenu, `restApiClientCodeGenerator.csharpSubmenu`, under the main `restApiClientCodeGenerator.submenu`, grouping all C# generation commands together.
* Introduced a new menu label, "C#", for the `restApiClientCodeGenerator.csharpSubmenu`, improving navigation and organization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a "C#" submenu under the "REST API Client Generator" context menu in VSCode, grouping all C# code generation commands for easier access.

- **Style**
  - Updated command titles to clearly indicate "Generate C# with" for all C# code generation options, improving clarity in the menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->