### PR TITLE
Update Microsoft Kiota package dependencies to version v1.17.3

### DIFF
--- a/src/Core/ApiClientCodeGen.Core/NuGet/PackageDependencies.cs
+++ b/src/Core/ApiClientCodeGen.Core/NuGet/PackageDependencies.cs
@@ -76,37 +76,37 @@ namespace Rapicgen.Core.NuGet
         public static readonly PackageDependency MicrosoftKiotaAbstractions =
             new PackageDependency(
                 "Microsoft.Kiota.Abstractions",
-                "1.17.2");
+                "1.17.3");
 
         public static readonly PackageDependency MicrosoftKiotaAuthenticationAzure =
             new PackageDependency(
                 "Microsoft.Kiota.Authentication.Azure",
-                "1.17.2");
+                "1.17.3");
 
         public static readonly PackageDependency MicrosoftKiotaHttpClientLibrary =
             new PackageDependency(
                 "Microsoft.Kiota.Http.HttpClientLibrary",
-                "1.17.2");
+                "1.17.3");
 
         public static readonly PackageDependency MicrosoftKiotaSerializationForm =
             new PackageDependency(
                 "Microsoft.Kiota.Serialization.Form",
-                "1.17.2");
+                "1.17.3");
 
         public static readonly PackageDependency MicrosoftKiotaSerializationJson =
             new PackageDependency(
                 "Microsoft.Kiota.Serialization.Json",
-                "1.17.2");
+                "1.17.3");
 
         public static readonly PackageDependency MicrosoftKiotaSerializationText =
             new PackageDependency(
                 "Microsoft.Kiota.Serialization.Text",
-                "1.17.2");
+                "1.17.3");
 
         public static readonly PackageDependency MicrosoftKiotaSerializationMultipart =
             new PackageDependency(
                 "Microsoft.Kiota.Serialization.Multipart",
-                "1.17.2");
+                "1.17.3");
 
         public static readonly PackageDependency Refit =
             new PackageDependency(

--- a/src/Core/ApiClientCodeGen.Tests.Common/Build/Projects/KiotaProjectFileContents.cs
+++ b/src/Core/ApiClientCodeGen.Tests.Common/Build/Projects/KiotaProjectFileContents.cs
@@ -9,12 +9,12 @@ namespace ApiClientCodeGen.Tests.Common.Build.Projects
                 <TargetFramework>net8.0</TargetFramework>
               </PropertyGroup>
               <ItemGroup>
-                <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.17.2" />
-                <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.17.2" />
-                <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.17.2" />
-                <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.17.2" />
-                <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.17.2" />
-                <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.17.2" />
+                <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.17.3" />
+                <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.17.3" />
+                <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.17.3" />
+                <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.17.3" />
+                <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.17.3" />
+                <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.17.3" />
               </ItemGroup>
             </Project>
             """;
@@ -26,12 +26,12 @@ namespace ApiClientCodeGen.Tests.Common.Build.Projects
                 <TargetFramework>netstandard2.1</TargetFramework>
               </PropertyGroup>
               <ItemGroup>
-                <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.17.2" />
-                <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.17.2" />
-                <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.17.2" />
-                <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.17.2" />
-                <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.17.2" />
-                <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.17.2" />
+                <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.17.3" />
+                <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.17.3" />
+                <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.17.3" />
+                <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.17.3" />
+                <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.17.3" />
+                <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.17.3" />
               </ItemGroup>
             </Project>
             """;

--- a/test/GeneratedCode/Kiota/Directory.build.props
+++ b/test/GeneratedCode/Kiota/Directory.build.props
@@ -3,11 +3,11 @@
     <Compile Include="../*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.17.2" />
-    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.17.2" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.17.2" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.17.2" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.17.2" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.17.2" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.17.3" />
+    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.17.3" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.17.3" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.17.3" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.17.3" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.17.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Upgrade all Microsoft Kiota package dependencies to version 1.17.3 across the main project, unit test projects, and smoke test projects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Microsoft.Kiota package dependencies to version 1.17.3 across the application and test projects. No functional changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->