### PR TITLE
Implement "Generate Refitter Output" in VS Code extension

### DIFF
--- a/src/VSCode/README.md
+++ b/src/VSCode/README.md
@@ -21,7 +21,7 @@ You can install this extension in several ways:
 
 ## Features
 
-This extension adds a context menu item **REST API Client Code Generator** when right-clicking on JSON or YAML files in the VS Code explorer. The context menu provides the following code generation options:
+This extension adds a context menu item **REST API Client Code Generator** when right-clicking on JSON or YAML files in the VS Code explorer. Additionally, it provides a **Generate Refitter Output** command when right-clicking on `.refitter` settings files. The context menu provides the following code generation options:
 
 ### C# Generators
 
@@ -44,6 +44,10 @@ This extension adds a context menu item **REST API Client Code Generator** when 
 - **Node**: Generates a TypeScript REST API Client for Node
 - **Redux Query**: Generates a TypeScript REST API Client for Redux Query
 - **RxJS**: Generates a TypeScript REST API Client for RxJS
+
+### Refitter Settings Support
+
+- **Generate Refitter Output**: When right-clicking on a `.refitter` settings file, you can generate C# Refit interfaces using Refitter with custom configuration. This allows for advanced Refitter configurations including custom settings for authentication, serialization, and other Refitter-specific options.
 
 ## Screenshot
 
@@ -77,11 +81,48 @@ The extension includes configurable settings:
 
 ## How to Use
 
+### For OpenAPI/Swagger Specifications
+
 1. Right-click on a Swagger/OpenAPI specification file (JSON or YAML) in the VS Code explorer
 2. Select "REST API Client Generator" in the context menu
 3. Choose your desired language (C# or TypeScript)
 4. Select one of the available generators for that language
 5. The generated code will be saved in the configured output directory and opened in the editor
+
+### For Refitter Settings Files
+
+1. Create a `.refitter` settings file with your Refitter configuration
+2. Right-click on the `.refitter` file in the VS Code explorer
+3. Select "Generate Refitter Output" from the context menu
+4. The generated C# Refit interfaces will be created according to your settings file configuration
+
+## Refitter Settings Files
+
+The extension supports Refitter settings files (`.refitter`) which allow you to configure advanced options for generating C# Refit interfaces. A typical `.refitter` settings file includes:
+
+- **OpenAPI specification URL or file path**
+- **Namespace configuration**
+- **Output file paths**
+- **Authentication settings**
+- **Serialization options**
+- **Custom type mappings**
+- **And many other Refitter-specific options**
+
+Example `.refitter` file:
+
+```json
+{
+  "openApiSpecUrl": "https://petstore.swagger.io/v2/swagger.json",
+  "namespace": "PetStore.Api",
+  "outputFolder": "./Generated",
+  "outputFilename": "PetStoreApi.cs",
+  "clientName": "PetStoreClient",
+  "generateContracts": true,
+  "generateXmlDocCodeComments": true
+}
+```
+
+For more information about Refitter settings, visit the [Refitter documentation](https://github.com/christianhelle/refitter).
 
 ## Dependencies
 

--- a/src/VSCode/package.json
+++ b/src/VSCode/package.json
@@ -89,6 +89,10 @@
       {
         "command": "restApiClientCodeGenerator.typescript.rxjs",
         "title": "Generate TypeScript Client for RxJS"
+      },
+      {
+        "command": "restApiClientCodeGenerator.refitterSettings",
+        "title": "Generate Refitter Output"
       }
     ],
     "menus": {
@@ -96,6 +100,11 @@
         {
           "submenu": "restApiClientCodeGenerator.submenu",
           "when": "resourceExtname == .json || resourceExtname == .yaml || resourceExtname == .yml",
+          "group": "z_commands"
+        },
+        {
+          "command": "restApiClientCodeGenerator.refitterSettings",
+          "when": "resourceExtname == .refitter",
           "group": "z_commands"
         }
       ],


### PR DESCRIPTION
This pull request introduces support for generating C# Refit interfaces using `.refitter` settings files in the VS Code extension. It adds a new command, updates the documentation, and implements the necessary functionality to process `.refitter` files. Below are the most important changes grouped by theme:

### Documentation Updates
* Updated `src/VSCode/README.md` to include a new section on **Refitter Settings Support** and detailed instructions for using `.refitter` settings files. This includes an example `.refitter` file and a link to the Refitter documentation. [[1]](diffhunk://#diff-90fe0ce841b75b67d68c7719e8299ed89828139a968ee7af59b2c7aeddcad38dL24-R24) [[2]](diffhunk://#diff-90fe0ce841b75b67d68c7719e8299ed89828139a968ee7af59b2c7aeddcad38dR48-R51) [[3]](diffhunk://#diff-90fe0ce841b75b67d68c7719e8299ed89828139a968ee7af59b2c7aeddcad38dR84-R126)

### Command Registration
* Added a new command `restApiClientCodeGenerator.refitterSettings` in `src/VSCode/package.json` to enable generating Refitter output. This command is triggered when right-clicking on `.refitter` files in the VS Code explorer. [[1]](diffhunk://#diff-a9847e1960b60422630e220dbc96ae0202818429d45fd05f8dfaafd1873ed27cR92-R95) [[2]](diffhunk://#diff-a9847e1960b60422630e220dbc96ae0202818429d45fd05f8dfaafd1873ed27cR104-R108)

### Core Functionality Implementation
* Implemented the `executeRapicgenRefitterSettings` function in `src/VSCode/src/extension.ts`. This function validates `.refitter` settings files, ensures the .NET SDK and Rapicgen tool are available, and executes the Refitter generation process with progress notifications and error handling.

### Command Handling
* Updated the `activate` function in `src/VSCode/src/extension.ts` to register the new command for `.refitter` settings files. It includes logic to handle file selection when the command is triggered from the command palette.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for generating C# Refit interfaces using custom `.refitter` settings files directly from the VS Code context menu.
  - Introduced a new "Generate Refitter Output" command accessible by right-clicking `.refitter` files.
- **Documentation**
  - Updated the README to include instructions, usage examples, and configuration details for the new Refitter-based code generation feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->