### PR TITLE
Fix VSIX Builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,11 +58,11 @@ jobs:
         ((Get-Content -Path VSIX/ApiClientCodeGen.VSIX.Dev17/source.extension.vsixmanifest -Raw) -Replace "1.0.0", "${{ env.VERSION }}") | Set-Content -Path VSIX/ApiClientCodeGen.VSIX.Dev17/source.extension.vsixmanifest
       working-directory: src
       shell: pwsh
-    - name: Restore
-      run: dotnet restore VSIX.sln
-      working-directory: src
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v2
+    - name: Restore
+      run: msbuild VSIX.sln -t:Restore
+      working-directory: src
     - name: Build
       run: msbuild VSIX.sln /property:Configuration=Release /p:DeployExtension=false
       working-directory: src

--- a/.github/workflows/sonar-cloud.yml
+++ b/.github/workflows/sonar-cloud.yml
@@ -68,12 +68,12 @@ jobs:
               /d:sonar.cs.vstest.reportsPaths=**/*.trx `
               /d:sonar.cs.vscoveragexml.reportsPaths=**/*.coveragexml
 
-      - name: Restore
-        run: dotnet restore VSIX.sln
-        working-directory: src
-
       - name: Setup MSBuild.exe
         uses: microsoft/setup-msbuild@v2
+
+      - name: Restore
+        run: msbuild VSIX.sln -t:Restore
+        working-directory: src
 
       - name: Build
         run: msbuild VSIX.sln /property:Configuration=Release /t:Rebuild

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -67,12 +67,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Restore
-      run: dotnet restore VSIX.sln
-      working-directory: src
-
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v2
+
+    - name: Restore
+      run: msbuild VSIX.sln -t:Restore
+      working-directory: src
 
     - name: Build
       run: msbuild VSIX.sln /property:Configuration=Release /t:Rebuild

--- a/.github/workflows/vsix.yml
+++ b/.github/workflows/vsix.yml
@@ -43,7 +43,11 @@ jobs:
       uses: microsoft/setup-msbuild@v2
 
     - name: Build
-      run: msbuild VSIX.sln /property:Configuration=Release /p:DeployExtension=false
+      run: msbuild VSIX/ApiClientCodeGen.VSIX.Dev17/ApiClientCodeGen.VSIX.Dev17.csproj /property:Configuration=Release /p:DeployExtension=false
+      working-directory: src
+
+    - name: Build
+      run: msbuild VSIX/ApiClientCodeGen.VSIX/ApiClientCodeGen.VSIX.csproj /property:Configuration=Release /p:DeployExtension=false
       working-directory: src
 
     - name: Move build output

--- a/.github/workflows/vsix.yml
+++ b/.github/workflows/vsix.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   build:
 
-    runs-on: windows-2025
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/vsix.yml
+++ b/.github/workflows/vsix.yml
@@ -35,11 +35,6 @@ jobs:
       working-directory: src
       shell: pwsh
 
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: '9.0.x'
-
     - name: Restore
       run: dotnet restore VSIX.sln
       working-directory: src

--- a/.github/workflows/vsix.yml
+++ b/.github/workflows/vsix.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v2
       with:
-        vs-version: '[16.4,16.5)'
+        vs-version: '[17.4,17.5)'
 
     - name: Build
       run: msbuild VSIX.sln /property:Configuration=Release /p:DeployExtension=false

--- a/.github/workflows/vsix.yml
+++ b/.github/workflows/vsix.yml
@@ -39,7 +39,7 @@ jobs:
       uses: microsoft/setup-msbuild@v2
 
     - name: Restore
-      run: dotnet restore VSIX.sln
+      run: msbuild VSIX.sln -t:Restore
       working-directory: src
 
     - name: Build VS 2022 Extension

--- a/.github/workflows/vsix.yml
+++ b/.github/workflows/vsix.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   build:
 
-    runs-on: windows-latest
+    runs-on: windows-2025
 
     steps:
     - uses: actions/checkout@v4
@@ -46,8 +46,6 @@ jobs:
 
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v2
-      with:
-        vs-version: '[17.0, 17.5)'
 
     - name: Build
       run: msbuild VSIX.sln /property:Configuration=Release /p:DeployExtension=false

--- a/.github/workflows/vsix.yml
+++ b/.github/workflows/vsix.yml
@@ -35,6 +35,11 @@ jobs:
       working-directory: src
       shell: pwsh
 
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '9.0.x'
+
     - name: Restore
       run: dotnet restore VSIX.sln
       working-directory: src

--- a/.github/workflows/vsix.yml
+++ b/.github/workflows/vsix.yml
@@ -35,18 +35,18 @@ jobs:
       working-directory: src
       shell: pwsh
 
+    - name: Setup MSBuild.exe
+      uses: microsoft/setup-msbuild@v2
+
     - name: Restore
       run: dotnet restore VSIX.sln
       working-directory: src
 
-    - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v2
-
-    - name: Build
+    - name: Build VS 2022 Extension
       run: msbuild VSIX/ApiClientCodeGen.VSIX.Dev17/ApiClientCodeGen.VSIX.Dev17.csproj /property:Configuration=Release /p:DeployExtension=false
       working-directory: src
 
-    - name: Build
+    - name: Build VS 2019 Extension
       run: msbuild VSIX/ApiClientCodeGen.VSIX/ApiClientCodeGen.VSIX.csproj /property:Configuration=Release /p:DeployExtension=false
       working-directory: src
 

--- a/.github/workflows/vsix.yml
+++ b/.github/workflows/vsix.yml
@@ -42,12 +42,8 @@ jobs:
       run: msbuild VSIX.sln -t:Restore
       working-directory: src
 
-    - name: Build VS 2022 Extension
-      run: msbuild VSIX/ApiClientCodeGen.VSIX.Dev17/ApiClientCodeGen.VSIX.Dev17.csproj /property:Configuration=Release /p:DeployExtension=false
-      working-directory: src
-
-    - name: Build VS 2019 Extension
-      run: msbuild VSIX/ApiClientCodeGen.VSIX/ApiClientCodeGen.VSIX.csproj /property:Configuration=Release /p:DeployExtension=false
+    - name: Build
+      run: msbuild VSIX.sln /property:Configuration=Release /p:DeployExtension=false
       working-directory: src
 
     - name: Move build output

--- a/.github/workflows/vsix.yml
+++ b/.github/workflows/vsix.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v2
       with:
-        vs-version: '[17.4,17.5)'
+        vs-version: '[17.0, 17.5)'
 
     - name: Build
       run: msbuild VSIX.sln /property:Configuration=Release /p:DeployExtension=false

--- a/.github/workflows/vsix.yml
+++ b/.github/workflows/vsix.yml
@@ -46,6 +46,8 @@ jobs:
 
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v2
+      with:
+        vs-version: '[16.4,16.5)'
 
     - name: Build
       run: msbuild VSIX.sln /property:Configuration=Release /p:DeployExtension=false


### PR DESCRIPTION
This pull request updates the workflows for building and releasing the VSIX project. The primary change involves switching from `dotnet restore` to `msbuild -t:Restore` for restoring dependencies in both the `release.yml` and `vsix.yml` workflow files.

Workflow updates:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L61-R65): Replaced `dotnet restore` with `msbuild -t:Restore` in the restore step to align with MSBuild usage for the VSIX solution.
* [`.github/workflows/vsix.yml`](diffhunk://#diff-ae11fa4ff511f041aedf10df04e6d045caaf4fb5401de2d77281f6e384c84029L38-R44): Updated the restore step to use `msbuild -t:Restore` instead of `dotnet restore`, ensuring consistency with the build process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated internal workflow steps for restoring dependencies during the build process. No changes to user-facing features or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->