### PR TITLE
Fix command syntax for executing Refitter settings from VS Code

### DIFF
--- a/src/VSCode/src/services/generators.ts
+++ b/src/VSCode/src/services/generators.ts
@@ -157,7 +157,7 @@ export async function executeRapicgenRefitterSettings(settingsFilePath: string, 
     return;
   }
 
-  const command = `rapicgen csharp refitter --settings-file "${settingsFilePath}"`;
+  const command = `rapicgen csharp refitter . --settings-file "${settingsFilePath}"`;
   
   await executeRapicgenCommand(command, 'Refitter', settingsFilePath, false, true);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Rapicgen Refitter execution to include the project context, preventing errors in certain environments.
  * Ensures code generation respects the provided settings file and runs reliably from the extension.
  * No action required from users; existing workflows continue to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->