### PR TITLE
Fix "Generate Refitter Output" command

### DIFF
--- a/src/Core/ApiClientCodeGen.Core.Tests/Installer/DependencyInstallerTests.cs
+++ b/src/Core/ApiClientCodeGen.Core.Tests/Installer/DependencyInstallerTests.cs
@@ -147,5 +147,155 @@ namespace ApiClientCodeGen.Core.Tests.Installer
                 .Should()
                 .ThrowExactly<ProcessLaunchException>();
         }
+
+        [Theory, AutoMoqData]
+        public void InstallRefitter_When_Refitter_Not_Installed_Invokes_ProcessLauncher_To_Install(
+            [Frozen] IProcessLauncher processLauncher,
+            DependencyInstaller sut)
+        {
+            var mock = Mock.Get(processLauncher);
+            // Setup the tool list command to return output without refitter
+            mock.Setup(
+                    c => c.Start(
+                        It.IsAny<string>(),
+                        "tool list --global",
+                        It.IsAny<Action<string>>(),
+                        It.IsAny<Action<string>>(),
+                        default))
+                .Callback<string, string, Action<string>, Action<string>, string>(
+                    (cmd, args, onOutput, onError, workingDir) =>
+                    {
+                        onOutput?.Invoke("Package Id      Version      Commands");
+                        onOutput?.Invoke("other-tool      1.0.0        other");
+                    });
+
+            sut.InstallRefitter();
+
+            mock.Verify(
+                c => c.Start(
+                    It.IsAny<string>(),
+                    "tool install --global refitter --version 1.6.2",
+                    null),
+                Times.Once);
+        }
+
+        [Theory, AutoMoqData]
+        public void InstallRefitter_When_Refitter_Installed_With_Old_Version_Invokes_ProcessLauncher_To_Install(
+            [Frozen] IProcessLauncher processLauncher,
+            DependencyInstaller sut)
+        {
+            var mock = Mock.Get(processLauncher);
+            // Setup the tool list command to return output with old refitter version
+            mock.Setup(
+                    c => c.Start(
+                        It.IsAny<string>(),
+                        "tool list --global",
+                        It.IsAny<Action<string>>(),
+                        It.IsAny<Action<string>>(),
+                        default))
+                .Callback<string, string, Action<string>, Action<string>, string>(
+                    (cmd, args, onOutput, onError, workingDir) =>
+                    {
+                        onOutput?.Invoke("Package Id      Version      Commands");
+                        onOutput?.Invoke("refitter        1.5.0        refitter");
+                    });
+
+            sut.InstallRefitter();
+
+            mock.Verify(
+                c => c.Start(
+                    It.IsAny<string>(),
+                    "tool install --global refitter --version 1.6.2",
+                    null),
+                Times.Once);
+        }
+
+        [Theory, AutoMoqData]
+        public void InstallRefitter_When_Refitter_Installed_With_Current_Version_Does_Not_Install(
+            [Frozen] IProcessLauncher processLauncher,
+            DependencyInstaller sut)
+        {
+            var mock = Mock.Get(processLauncher);
+            // Setup the tool list command to return output with current refitter version
+            mock.Setup(
+                    c => c.Start(
+                        It.IsAny<string>(),
+                        "tool list --global",
+                        It.IsAny<Action<string>>(),
+                        It.IsAny<Action<string>>(),
+                        default))
+                .Callback<string, string, Action<string>, Action<string>, string>(
+                    (cmd, args, onOutput, onError, workingDir) =>
+                    {
+                        onOutput?.Invoke("Package Id      Version      Commands");
+                        onOutput?.Invoke("refitter        1.6.2        refitter");
+                    });
+
+            sut.InstallRefitter();
+
+            mock.Verify(
+                c => c.Start(
+                    It.IsAny<string>(),
+                    "tool install --global refitter --version 1.6.2",
+                    null),
+                Times.Never);
+        }
+
+        [Theory, AutoMoqData]
+        public void InstallRefitter_When_Refitter_Installed_With_Newer_Version_Does_Not_Install(
+            [Frozen] IProcessLauncher processLauncher,
+            DependencyInstaller sut)
+        {
+            var mock = Mock.Get(processLauncher);
+            // Setup the tool list command to return output with newer refitter version
+            mock.Setup(
+                    c => c.Start(
+                        It.IsAny<string>(),
+                        "tool list --global",
+                        It.IsAny<Action<string>>(),
+                        It.IsAny<Action<string>>(),
+                        default))
+                .Callback<string, string, Action<string>, Action<string>, string>(
+                    (cmd, args, onOutput, onError, workingDir) =>
+                    {
+                        onOutput?.Invoke("Package Id      Version      Commands");
+                        onOutput?.Invoke("refitter        1.7.0        refitter");
+                    });
+
+            sut.InstallRefitter();
+
+            mock.Verify(
+                c => c.Start(
+                    It.IsAny<string>(),
+                    "tool install --global refitter --version 1.6.2",
+                    null),
+                Times.Never);
+        }
+
+        [Theory, AutoMoqData]
+        public void InstallRefitter_When_DotNet_Tool_List_Fails_Invokes_ProcessLauncher_To_Install(
+            [Frozen] IProcessLauncher processLauncher,
+            DependencyInstaller sut)
+        {
+            var mock = Mock.Get(processLauncher);
+            // Setup the tool list command to throw exception
+            mock.Setup(
+                    c => c.Start(
+                        It.IsAny<string>(),
+                        "tool list --global",
+                        It.IsAny<Action<string>>(),
+                        It.IsAny<Action<string>>(),
+                        default))
+                .Throws(new Win32Exception());
+
+            sut.InstallRefitter();
+
+            mock.Verify(
+                c => c.Start(
+                    It.IsAny<string>(),
+                    "tool install --global refitter --version 1.6.2",
+                    null),
+                Times.Once);
+        }
     }
 }


### PR DESCRIPTION
This pull request enhances the installation logic for the Refitter tool in the `DependencyInstaller` and adds comprehensive tests to cover various installation scenarios. The main improvement is a more robust check for the installed version of Refitter using the output from `dotnet tool list --global`, ensuring the tool is only installed or updated when necessary. Several new unit tests verify this behavior under different conditions.

**Improvements to Refitter installation logic:**

* Updated `InstallRefitter()` in `DependencyInstaller.cs` to parse the output of `dotnet tool list --global` to detect if Refitter is installed and determine its version, installing or updating only if the required version (1.6.2) is missing or outdated. [[1]](diffhunk://#diff-980179b4c3d63e317953dc79e5e30db3008983af2a72c953bd006a8af9502582L94-R106) [[2]](diffhunk://#diff-980179b4c3d63e317953dc79e5e30db3008983af2a72c953bd006a8af9502582L113-R131) [[3]](diffhunk://#diff-980179b4c3d63e317953dc79e5e30db3008983af2a72c953bd006a8af9502582R140-R147)
* Improved error handling in `InstallRefitter()` to attempt installation if the tool listing command fails (e.g., due to a missing or broken `dotnet` executable).

**Expanded test coverage:**

* Added multiple unit tests in `DependencyInstallerTests.cs` to verify that `InstallRefitter()` correctly installs, updates, or skips installation of Refitter based on its presence and version, and handles failures in the tool listing command.…r argument

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improves reliability of detecting the Refitter tool via global tools list.
  - Automatically installs required version (1.6.2) when missing or outdated; skips installation if current or newer.
  - Adds fallback to installation when tool listing fails, reducing setup failures.

- Tests
  - Adds comprehensive test coverage for installation flows, including not installed, outdated, current, newer, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

This fixes #1321 