### PR TITLE
OpenAPI Generator v7.16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Custom tools let you associate a tool with an item in a project and run that too
 
 - ***NSwagCodeGenerator*** - Generates a single file C# REST API Client using the [NSwag.CodeGeneration.CSharp](https://github.com/RSuter/NSwag/wiki/CSharpClientGenerator) [nuget package](https://www.nuget.org/packages/NSwag.CodeGeneration.CSharp/) **v14.4.0**
 
-- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **[OpenAPI Generator v7.15.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.15.0)**.
+- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **[OpenAPI Generator v7.16.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.16.0)**.
 The output file is the result of merging all the files generated using the OpenAPI Generator tool with:
 `generate -g csharp --input-spec [swagger file] --output [output file] -DapiTests=false -DmodelTests=false -DpackageName=[default namespace] --skip-overwrite`. It is possible to configure the OpenAPI Generator to generate multiple files which will be placed at the same path as the OpenAPI specifications document that was used to generate code, this is done under Tools -> REST API Client Code Generator -> OpenAPI Generator and setting **Generate Multiple Files** to **true**
 
@@ -348,7 +348,7 @@ Options:
 Commands:
   csharp             Generate C# API clients
   jmeter             Generate Apache JMeter test plans
-  openapi-generator  Generate code using OpenAPI Generator (v7.15.0).
+  openapi-generator  Generate code using OpenAPI Generator (v7.16.0).
                      See supported generators at https://openapi-generator.tech/docs/generators/
   typescript         Generate TypeScript API clients
 
@@ -387,7 +387,7 @@ Commands:
   autorest      AutoRest (v3.0.0-beta.20210504.2)
   kiota         Microsoft Kiota (v1.28.0)
   nswag         NSwag (v14.4.0)
-  openapi       OpenAPI Generator (v7.15.0)
+  openapi       OpenAPI Generator (v7.16.0)
   refitter      Refitter (v1.6.3)
   swagger       Swagger Codegen CLI (v3.0.34)
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -33,7 +33,7 @@ Options:
 Commands:
   csharp             Generate C# API clients
   jmeter             Generate Apache JMeter test plans
-  openapi-generator  Generate code using OpenAPI Generator (v7.15.0).
+  openapi-generator  Generate code using OpenAPI Generator (v7.16.0).
                      See supported generators at https://openapi-generator.tech/docs/generators/
   typescript         Generate TypeScript API clients
 
@@ -72,7 +72,7 @@ Commands:
   autorest      AutoRest (v3.0.0-beta.20210504.2)
   kiota         Microsoft Kiota (v1.28.0)
   nswag         NSwag (v14.4.0)
-  openapi       OpenAPI Generator (v7.15.0)
+  openapi       OpenAPI Generator (v7.16.0)
   refitter      Refitter (v1.6.3)
   swagger       Swagger Codegen CLI (v3.0.34)
 

--- a/docs/Marketplace.md
+++ b/docs/Marketplace.md
@@ -27,7 +27,7 @@ A collection of Visual Studio C# custom tool code generators for Swagger / OpenA
 
 - ***NSwagCodeGenerator*** - Generates a single file C# REST API Client using the [NSwag.CodeGeneration.CSharp](https://github.com/RSuter/NSwag/wiki/CSharpClientGenerator) [nuget package](https://www.nuget.org/packages/NSwag.CodeGeneration.CSharp/) **v14.4.0**
 
-- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **[OpenAPI Generator v7.15.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.15.0)**.
+- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **[OpenAPI Generator v7.16.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.16.0)**.
 The output file is the result of merging all the files generated using the OpenAPI Generator tool with:
 `generate -g csharp --input-spec [swagger file] --output [output file] -DapiTests=false -DmodelTests=false -DpackageName=[default namespace] --skip-overwrite`. It is possible to configure the OpenAPI Generator to generate multiple files which will be placed at the same path as the OpenAPI specifications document that was used to generate code, this is done under Tools -> REST API Client Code Generator -> OpenAPI Generator and setting **Generate Multiple Files** to **true**
 

--- a/docs/Marketplace2022.md
+++ b/docs/Marketplace2022.md
@@ -27,7 +27,7 @@ A collection of Visual Studio C# custom tool code generators for Swagger / OpenA
 
 - ***NSwagCodeGenerator*** - Generates a single file C# REST API Client using the [NSwag.CodeGeneration.CSharp](https://github.com/RSuter/NSwag/wiki/CSharpClientGenerator) [nuget package](https://www.nuget.org/packages/NSwag.CodeGeneration.CSharp/) **v14.4.0**
 
-- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **[OpenAPI Generator v7.15.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.15.0)**.
+- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **[OpenAPI Generator v7.16.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.16.0)**.
 The output file is the result of merging all the files generated using the OpenAPI Generator tool with:
 `generate -g csharp --input-spec [swagger file] --output [output file] -DapiTests=false -DmodelTests=false -DpackageName=[default namespace] --skip-overwrite`. It is possible to configure the OpenAPI Generator to generate multiple files which will be placed at the same path as the OpenAPI specifications document that was used to generate code, this is done under Tools -> REST API Client Code Generator -> OpenAPI Generator and setting **Generate Multiple Files** to **true**
 

--- a/docs/VisualStudioForMac.md
+++ b/docs/VisualStudioForMac.md
@@ -13,7 +13,7 @@ A collection of Visual Studio C# custom tool code generators for Swagger / OpenA
 
 - ***NSwagCodeGenerator*** - Generates a single file C# REST API Client using the [NSwag.CodeGeneration.CSharp](https://github.com/RSuter/NSwag/wiki/CSharpClientGenerator) [nuget package](https://www.nuget.org/packages/NSwag.CodeGeneration.CSharp/) **v14.4.0**
 
-- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **[OpenAPI Generator v7.15.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.15.0)**.
+- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **[OpenAPI Generator v7.16.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.16.0)**.
 The output file is the result of merging all the files generated using the OpenAPI Generator tool with:
 `generate -g csharp --input-spec [swagger file] --output [output file] -DapiTests=false -DmodelTests=false -DpackageName=[default namespace] --skip-overwrite`
 

--- a/docs/website/cli.html
+++ b/docs/website/cli.html
@@ -122,7 +122,7 @@ Options:
 Commands:
   csharp             Generate C# API clients
   jmeter             Generate Apache JMeter test plans
-  openapi-generator  Generate code using OpenAPI Generator (v7.15.0).
+  openapi-generator  Generate code using OpenAPI Generator (v7.16.0).
                      See supported generators at https://openapi-generator.tech/docs/generators/
   typescript         Generate TypeScript API clients
 
@@ -146,7 +146,7 @@ Commands:
   autorest      AutoRest (v3.0.0-beta.20210504.2)
   kiota         Microsoft Kiota (v1.28.0)
   nswag         NSwag (v14.4.0)
-  openapi       OpenAPI Generator (v7.15.0)
+  openapi       OpenAPI Generator (v7.16.0)
   refitter      Refitter (v1.6.3)
   swagger       Swagger Codegen CLI (v3.0.34)
 

--- a/docs/website/features.html
+++ b/docs/website/features.html
@@ -111,7 +111,7 @@
 
           <div class="card">
             <h3>OpenApiCodeGenerator</h3>
-            <p><strong>Version:</strong> v7.15.0</p>
+            <p><strong>Version:</strong> v7.16.0</p>
             <p>Generates a single file C# REST API Client using OpenAPI Generator. The output file merges all generated files using the command: <code>generate -g csharp --input-spec [swagger file] --output [output file] -DapiTests=false -DmodelTests=false -DpackageName=[namespace] --skip-overwrite</code></p>
             <div class="config-section">
               <h4>Configuration Options:</h4>

--- a/docs/website/index.html
+++ b/docs/website/index.html
@@ -144,7 +144,7 @@
           
           <div class="card">
             <h3>OpenAPI Generator</h3>
-            <p><strong>Version:</strong> v7.15.0</p>
+            <p><strong>Version:</strong> v7.16.0</p>
             <p>Uses OpenAPI Generator to create comprehensive client libraries with extensive customization options. Supports multiple output formats and advanced configuration through additional properties.</p>
             <p><strong>Dependencies:</strong> RestSharp, JsonSubTypes, Polly, Newtonsoft.Json</p>
           </div>

--- a/src/CLI/ApiClientCodeGen.CLI/Program.cs
+++ b/src/CLI/ApiClientCodeGen.CLI/Program.cs
@@ -61,7 +61,7 @@ namespace Rapicgen.CLI
                             .WithExample(new[] { "swagger", "petstore.json", "GeneratedCode", "Output.cs" });
 
                         cs.AddCommand<OpenApiCSharpGeneratorCommand>("openapi")
-                            .WithDescription("OpenAPI Generator (v7.15.0)")
+                            .WithDescription("OpenAPI Generator (v7.16.0)")
                             .WithExample(new[] { "openapi", "petstore.json", "GeneratedCode", "Output.cs" });
                     });
 

--- a/src/Core/ApiClientCodeGen.Core/Installer/OpenApiGeneratorVersions.cs
+++ b/src/Core/ApiClientCodeGen.Core/Installer/OpenApiGeneratorVersions.cs
@@ -12,6 +12,12 @@ public static class OpenApiGeneratorVersions
     private static readonly OpenApiGeneratorVersion[] Versions =
     [
         new(
+            "7.16.0",
+            $"{DownloadUrlPrefix}/7.16.0/openapi-generator-cli-7.16.0.jar",
+            "2ca15745dbb9261a43392e7d9a530e5b7473e929",
+            "eff25f7e653b5986786eee6fc4722e47"
+        ),
+        new(
             "7.15.0",
             $"{DownloadUrlPrefix}/7.15.0/openapi-generator-cli-7.15.0.jar",
             "bb58e257f724fb46b7f2b309a9fa98e63fd7199f",

--- a/src/Core/ApiClientCodeGen.Core/Options/OpenApiGenerator/OpenApiSupportedVersion.cs
+++ b/src/Core/ApiClientCodeGen.Core/Options/OpenApiGenerator/OpenApiSupportedVersion.cs
@@ -12,6 +12,8 @@ public enum OpenApiSupportedVersion
     [Description("Latest")]
     Latest = 0,
 
+    [Description("7.16.0")]
+    V7160 = 7160,
     [Description("7.15.0")]
     V7150 = 7150,
     [Description("7.14.0")]
@@ -37,5 +39,5 @@ public static class OpenApiSupportedVersionExtensions
     /// <summary>
     /// Gets the latest supported version of OpenAPI Generator
     /// </summary>
-    public static OpenApiSupportedVersion Latest => OpenApiSupportedVersion.V7150;
+    public static OpenApiSupportedVersion Latest => OpenApiSupportedVersion.V7160;
 }

--- a/src/Core/ApiClientCodeGen.Core/Resource.Designer.cs
+++ b/src/Core/ApiClientCodeGen.Core/Resource.Designer.cs
@@ -78,7 +78,7 @@ namespace Rapicgen.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.15.0/openapi-generator-cli-7.15.0.jar.
+        ///   Looks up a localized string similar to https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.16.0/openapi-generator-cli-7.16.0.jar.
         /// </summary>
         public static string OpenApiGenerator_DownloadUrl {
             get {
@@ -87,7 +87,7 @@ namespace Rapicgen.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to b617d5137b022a9b3304b1a26d0b3110.
+        ///   Looks up a localized string similar to eff25f7e653b5986786eee6fc4722e47.
         /// </summary>
         public static string OpenApiGenerator_MD5 {
             get {
@@ -96,7 +96,7 @@ namespace Rapicgen.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to bb58e257f724fb46b7f2b309a9fa98e63fd7199f.
+        ///   Looks up a localized string similar to 2ca15745dbb9261a43392e7d9a530e5b7473e929.
         /// </summary>
         public static string OpenApiGenerator_SHA1 {
             get {

--- a/src/Core/ApiClientCodeGen.Core/Resource.resx
+++ b/src/Core/ApiClientCodeGen.Core/Resource.resx
@@ -118,13 +118,13 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="OpenApiGenerator_DownloadUrl" xml:space="preserve">
-    <value>https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.15.0/openapi-generator-cli-7.15.0.jar</value>
+    <value>https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.16.0/openapi-generator-cli-7.16.0.jar</value>
   </data>
   <data name="OpenApiGenerator_MD5" xml:space="preserve">
-    <value>b617d5137b022a9b3304b1a26d0b3110</value>
+    <value>eff25f7e653b5986786eee6fc4722e47</value>
   </data>
   <data name="OpenApiGenerator_SHA1" xml:space="preserve">
-    <value>bb58e257f724fb46b7f2b309a9fa98e63fd7199f</value>
+    <value>2ca15745dbb9261a43392e7d9a530e5b7473e929</value>
   </data>
   <data name="SwaggerCodegenCli_DownloadUrl" xml:space="preserve">
     <value>https://repo1.maven.org/maven2/io/swagger/codegen/v3/swagger-codegen-cli/3.0.34/swagger-codegen-cli-3.0.34.jar</value>

--- a/src/VSCode/package.json
+++ b/src/VSCode/package.json
@@ -36,7 +36,7 @@
       },
       {
         "command": "restApiClientCodeGenerator.openapi",
-        "title": "Generate C# Client with OpenAPI Generator (v7.15.0)"
+        "title": "Generate C# Client with OpenAPI Generator (v7.16.0)"
       },
       {
         "command": "restApiClientCodeGenerator.kiota",

--- a/src/VSIX/ApiClientCodeGen.VSIX.Dev17/VSCommandTable.vsct
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Dev17/VSCommandTable.vsct
@@ -39,7 +39,7 @@
       </Button>
       <Button guid="guidPackageCmdSet" id="OpenApiCodeGeneratorCustomToolSetter" priority="0x0101" type="Button">
         <Strings>
-          <ButtonText>Generate with OpenAPI Generator (v7.15.0)</ButtonText>
+          <ButtonText>Generate with OpenAPI Generator (v7.16.0)</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidPackageCmdSet" id="KiotaCodeGeneratorCustomToolSetter" priority="0x0102" type="Button">
@@ -99,7 +99,7 @@
       </Button>
       <Button guid="guidNewRestApiClientCmdSet" id="GenerateWithOpenApi" priority="0x0102" type="Button">
         <Strings>
-          <ButtonText>Generate with OpenAPI Generator (v7.15.0)</ButtonText>
+          <ButtonText>Generate with OpenAPI Generator (v7.16.0)</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidNewRestApiClientCmdSet" id="GenerateWithKiota" priority="0x0103" type="Button">

--- a/src/VSIX/ApiClientCodeGen.VSIX/VSCommandTable.vsct
+++ b/src/VSIX/ApiClientCodeGen.VSIX/VSCommandTable.vsct
@@ -39,7 +39,7 @@
       </Button>
       <Button guid="guidPackageCmdSet" id="OpenApiCodeGeneratorCustomToolSetter" priority="0x0101" type="Button">
         <Strings>
-          <ButtonText>Generate with OpenAPI Generator (v7.15.0)</ButtonText>
+          <ButtonText>Generate with OpenAPI Generator (v7.16.0)</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidPackageCmdSet" id="KiotaCodeGeneratorCustomToolSetter" priority="0x0102" type="Button">
@@ -99,7 +99,7 @@
       </Button>
       <Button guid="guidNewRestApiClientCmdSet" id="GenerateWithOpenApi" priority="0x0102" type="Button">
         <Strings>
-          <ButtonText>Generate with OpenAPI Generator (v7.15.0)</ButtonText>
+          <ButtonText>Generate with OpenAPI Generator (v7.16.0)</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidNewRestApiClientCmdSet" id="GenerateWithKiota" priority="0x0103" type="Button">

--- a/src/VSMac/ApiClientCodeGen.VSMac/Properties/Manifest.addin.xml
+++ b/src/VSMac/ApiClientCodeGen.VSMac/Properties/Manifest.addin.xml
@@ -35,7 +35,7 @@
                  defaultHandler="ApiClientCodeGen.VSMac.Commands.Handlers.AddNewNSwagStudioCommandHandler" />
 
         <Command id = "ApiClientCodeGen.VSMac.Commands.AddToProject.OpenApi"
-                 _label = "Generate with OpenAPI Generator (v7.15.0)"
+                 _label = "Generate with OpenAPI Generator (v7.16.0)"
                  defaultHandler="ApiClientCodeGen.VSMac.Commands.Handlers.AddNewOpenApiCommandHandler" />
 
         <Command id = "ApiClientCodeGen.VSMac.Commands.AddToProject.Kiota"
@@ -64,7 +64,7 @@
                  defaultHandler="ApiClientCodeGen.VSMac.Commands.Handlers.GenerateNSwagStudioCommandHandler" />
 
         <Command id = "ApiClientCodeGen.VSMac.Commands.GenerateCode.OpenApi"
-                 _label = "Generate with OpenAPI Generator (v7.15.0)"
+                 _label = "Generate with OpenAPI Generator (v7.16.0)"
                  defaultHandler="ApiClientCodeGen.VSMac.Commands.Handlers.GenerateOpenApiCommandHandler" />
 
         <Command id = "ApiClientCodeGen.VSMac.Commands.GenerateCode.Kiota"


### PR DESCRIPTION
Upgrade the OpenAPI Generator to version 7.16.0 across all relevant components, including command descriptions, context menus, and documentation. Update checksums and add the new version to the supported versions list.