### PR TITLE
Update command icons to use context-appropriate monikers

### DIFF
--- a/src/VSIX/ApiClientCodeGen.VSIX.Extensibility/Commands/AboutCommand.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Extensibility/Commands/AboutCommand.cs
@@ -10,7 +10,7 @@ public class AboutCommand : Command
 {
     public override CommandConfiguration CommandConfiguration => new("%AboutCommand.DisplayName%")
     {
-        Icon = new(ImageMoniker.KnownValues.Extension, IconSettings.IconAndText),
+        Icon = new(ImageMoniker.KnownValues.AboutBox, IconSettings.IconAndText),
         Placements = [CommandPlacement.KnownPlacements.ExtensionsMenu]
     };
 

--- a/src/VSIX/ApiClientCodeGen.VSIX.Extensibility/Commands/AutoRestCommands.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Extensibility/Commands/AutoRestCommands.cs
@@ -19,7 +19,7 @@ public class GenerateAutoRestCommand(TraceSource traceSource, ExtensionSettingsP
     public override CommandConfiguration CommandConfiguration
         => new("%AutoRestCommand.DisplayName%")
         {
-            Icon = new(ImageMoniker.KnownValues.Extension, IconSettings.IconAndText),
+            Icon = new(ImageMoniker.KnownValues.GenerateFile, IconSettings.IconAndText),
             VisibleWhen = ActivationConstraint.ClientContext(
                 ClientContextKey.Shell.ActiveSelectionFileName,
                 ".(json|ya?ml)")
@@ -44,7 +44,7 @@ public class GenerateAutoRestNewCommand(TraceSource traceSource, ExtensionSettin
     public override CommandConfiguration CommandConfiguration
         => new("%AutoRestCommand.DisplayName%")
         {
-            Icon = new(ImageMoniker.KnownValues.Extension, IconSettings.IconAndText),
+            Icon = new(ImageMoniker.KnownValues.GenerateFile, IconSettings.IconAndText),
         };
 
     public override async Task ExecuteCommandAsync(

--- a/src/VSIX/ApiClientCodeGen.VSIX.Extensibility/Commands/KiotaCommands.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Extensibility/Commands/KiotaCommands.cs
@@ -16,7 +16,7 @@ public class GenerateKiotaCommand(TraceSource traceSource, ExtensionSettingsProv
 {
     public override CommandConfiguration CommandConfiguration => new("%KiotaCommand.DisplayName%")
     {
-        Icon = new(ImageMoniker.KnownValues.Extension, IconSettings.IconAndText),
+        Icon = new(ImageMoniker.KnownValues.GenerateFile, IconSettings.IconAndText),
         VisibleWhen = ActivationConstraint.ClientContext(ClientContextKey.Shell.ActiveSelectionFileName, ".(json|ya?ml)")
     };
 
@@ -37,7 +37,7 @@ public class GenerateKiotaNewCommand(TraceSource traceSource, ExtensionSettingsP
 {
     public override CommandConfiguration CommandConfiguration => new("%KiotaCommand.DisplayName%")
     {
-        Icon = new(ImageMoniker.KnownValues.Extension, IconSettings.IconAndText),
+        Icon = new(ImageMoniker.KnownValues.GenerateFile, IconSettings.IconAndText),
     };
 
     public override async Task ExecuteCommandAsync(

--- a/src/VSIX/ApiClientCodeGen.VSIX.Extensibility/Commands/NSwagCommands.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Extensibility/Commands/NSwagCommands.cs
@@ -22,7 +22,7 @@ public class GenerateNSwagCommand(TraceSource traceSource, ExtensionSettingsProv
 {
     public override CommandConfiguration CommandConfiguration => new("%NSwagCommand.DisplayName%")
     {
-        Icon = new(ImageMoniker.KnownValues.Extension, IconSettings.IconAndText),
+        Icon = new(ImageMoniker.KnownValues.GenerateFile, IconSettings.IconAndText),
         VisibleWhen = ActivationConstraint.ClientContext(
             ClientContextKey.Shell.ActiveSelectionFileName, 
             ".(json|ya?ml)")
@@ -48,7 +48,7 @@ public class GenerateNSwagStudioCommand(
 {
     public override CommandConfiguration CommandConfiguration => new("%NSwagStudioCommand.DisplayName%")
     {
-        Icon = new(ImageMoniker.KnownValues.Extension, IconSettings.IconAndText),
+        Icon = new(ImageMoniker.KnownValues.GenerateFile, IconSettings.IconAndText),
         Placements = [KnownPlacements.Node_IncludeExcludeGroup],
         VisibleWhen = ActivationConstraint.ClientContext(
             ClientContextKey.Shell.ActiveSelectionFileName,
@@ -123,7 +123,7 @@ public class GenerateNSwagNewCommand(TraceSource traceSource, ExtensionSettingsP
 {
     public override CommandConfiguration CommandConfiguration => new("%NSwagCommand.DisplayName%")
     {
-        Icon = new(ImageMoniker.KnownValues.Extension, IconSettings.IconAndText),
+        Icon = new(ImageMoniker.KnownValues.GenerateFile, IconSettings.IconAndText),
     };
 
     public override async Task ExecuteCommandAsync(

--- a/src/VSIX/ApiClientCodeGen.VSIX.Extensibility/Commands/OpenApiGeneratorCommands.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Extensibility/Commands/OpenApiGeneratorCommands.cs
@@ -16,7 +16,7 @@ public class GenerateOpenApiCommand(TraceSource traceSource, ExtensionSettingsPr
 {
     public override CommandConfiguration CommandConfiguration => new("%OpenApiGeneratorCommand.DisplayName%")
     {
-        Icon = new(ImageMoniker.KnownValues.Extension, IconSettings.IconAndText),
+        Icon = new(ImageMoniker.KnownValues.GenerateFile, IconSettings.IconAndText),
         VisibleWhen = ActivationConstraint.ClientContext(ClientContextKey.Shell.ActiveSelectionFileName, ".(json|ya?ml)")
     };
 
@@ -38,7 +38,7 @@ public class GenerateOpenApiNewCommand(TraceSource traceSource, ExtensionSetting
 {
     public override CommandConfiguration CommandConfiguration => new("%OpenApiGeneratorCommand.DisplayName%")
     {
-        Icon = new(ImageMoniker.KnownValues.Extension, IconSettings.IconAndText),
+        Icon = new(ImageMoniker.KnownValues.GenerateFile, IconSettings.IconAndText),
     };
 
     public override async Task ExecuteCommandAsync(

--- a/src/VSIX/ApiClientCodeGen.VSIX.Extensibility/Commands/RefitterCommands.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Extensibility/Commands/RefitterCommands.cs
@@ -18,7 +18,7 @@ public class GenerateRefitterCommand(TraceSource traceSource, ExtensionSettingsP
     public override CommandConfiguration CommandConfiguration
         => new("%RefitterCommand.DisplayName%")
         {
-            Icon = new(ImageMoniker.KnownValues.Extension, IconSettings.IconAndText),
+            Icon = new(ImageMoniker.KnownValues.GenerateFile, IconSettings.IconAndText),
             VisibleWhen = ActivationConstraint.ClientContext(
             ClientContextKey.Shell.ActiveSelectionFileName,
             ".(json|ya?ml)")
@@ -43,7 +43,7 @@ public class GenerateRefitterSettingsCommand(TraceSource traceSource, ExtensionS
     public override CommandConfiguration CommandConfiguration
         => new("%RefitterSettingsCommand.DisplayName%")
         {
-            Icon = new(ImageMoniker.KnownValues.Extension, IconSettings.IconAndText),
+            Icon = new(ImageMoniker.KnownValues.GenerateFile, IconSettings.IconAndText),
             Placements = [KnownPlacements.Node_IncludeExcludeGroup],
             VisibleWhen = ActivationConstraint.ClientContext(
                 ClientContextKey.Shell.ActiveSelectionFileName,
@@ -69,7 +69,7 @@ public class GenerateRefitterNewCommand(TraceSource traceSource, ExtensionSettin
     public override CommandConfiguration CommandConfiguration
         => new("%RefitterCommand.DisplayName%")
         {
-            Icon = new(ImageMoniker.KnownValues.Extension, IconSettings.IconAndText),
+            Icon = new(ImageMoniker.KnownValues.GenerateFile, IconSettings.IconAndText),
         };
 
     public override async Task ExecuteCommandAsync(

--- a/src/VSIX/ApiClientCodeGen.VSIX.Extensibility/Commands/SwaggerCodegenCommands.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Extensibility/Commands/SwaggerCodegenCommands.cs
@@ -16,7 +16,7 @@ public class GenerateSwaggerCommand(TraceSource traceSource, ExtensionSettingsPr
 {
     public override CommandConfiguration CommandConfiguration => new("%SwaggerCommand.DisplayName%")
     {
-        Icon = new(ImageMoniker.KnownValues.Extension, IconSettings.IconAndText),
+        Icon = new(ImageMoniker.KnownValues.GenerateFile, IconSettings.IconAndText),
         VisibleWhen = ActivationConstraint.ClientContext(ClientContextKey.Shell.ActiveSelectionFileName, ".(json|ya?ml)")
     };
 
@@ -37,7 +37,7 @@ public class GenerateSwaggerNewCommand(TraceSource traceSource, ExtensionSetting
 {
     public override CommandConfiguration CommandConfiguration => new("%SwaggerCommand.DisplayName%")
     {
-        Icon = new(ImageMoniker.KnownValues.Extension, IconSettings.IconAndText),
+        Icon = new(ImageMoniker.KnownValues.GenerateFile, IconSettings.IconAndText),
     };
 
     public override async Task ExecuteCommandAsync(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated icons for code generation commands (AutoRest, Kiota, NSwag, OpenAPI Generator, Refitter, Swagger) and the About command for improved visual consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->