### PR TITLE
Fix full path issues for NSwag, Refitter and Kiota

### DIFF
--- a/src/Core/ApiClientCodeGen.Core.Tests/Generators/Kiota/KiotaCodeGeneratorTests.cs
+++ b/src/Core/ApiClientCodeGen.Core.Tests/Generators/Kiota/KiotaCodeGeneratorTests.cs
@@ -29,7 +29,7 @@ public class KiotaCodeGeneratorTests
         sut.GenerateCode(null);
         Mock.Get(processLauncher)
             .Verify(
-                x => x.Start("kiota", It.IsAny<string>(), null),
+                x => x.Start(It.IsAny<string>(), It.IsAny<string>(), null),
                 Times.Once);
     }
 

--- a/src/Core/ApiClientCodeGen.Core.Tests/Generators/NSwag/NSwagCSharpCodeGeneratorTests.cs
+++ b/src/Core/ApiClientCodeGen.Core.Tests/Generators/NSwag/NSwagCSharpCodeGeneratorTests.cs
@@ -56,7 +56,7 @@ namespace ApiClientCodeGen.Core.Tests.Generators.NSwag
         public void Launches_NSwag_Process()
             => processLauncherMock.Verify(
                 c => c.Start(
-                    It.Is<string>(s => s == "nswag"),
+                    It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<string>()),
                 Times.Once);

--- a/src/Core/ApiClientCodeGen.Core.Tests/Generators/Refitter/RefitterCodeGeneratorTests.cs
+++ b/src/Core/ApiClientCodeGen.Core.Tests/Generators/Refitter/RefitterCodeGeneratorTests.cs
@@ -41,7 +41,7 @@ public class RefitterCodeGeneratorTests
 
             processLauncher.Verify(
                 p => p.Start(
-                    "refitter",
+                    It.IsAny<string>(),
                     It.Is<string>(s => s.Contains("--multiple-files")),
                     It.IsAny<string>()),
                 Times.Once);
@@ -82,7 +82,7 @@ public class RefitterCodeGeneratorTests
 
             processLauncher.Verify(
                 p => p.Start(
-                    "refitter",
+                    It.IsAny<string>(),
                     It.Is<string>(s => !s.Contains("--multiple-files")),
                     It.IsAny<string>()),
                 Times.Once);
@@ -160,7 +160,7 @@ public class RefitterCodeGeneratorTests
             var expectedDir = Path.GetTempPath().TrimEnd(Path.DirectorySeparatorChar);
             processLauncher.Verify(
                 p => p.Start(
-                    "refitter",
+                    It.IsAny<string>(),
                     It.Is<string>(s =>
                         s.Contains("--multiple-files") &&
                         s.Contains($"--output \"{expectedDir}\"")),

--- a/src/Core/ApiClientCodeGen.Core.Tests/Installer/DependencyInstallerTests.cs
+++ b/src/Core/ApiClientCodeGen.Core.Tests/Installer/DependencyInstallerTests.cs
@@ -194,7 +194,7 @@ namespace ApiClientCodeGen.Core.Tests.Installer
         }
 
         [Theory, AutoMoqData]
-        public void InstallRefitter_When_Refitter_Installed_With_Old_Version_Invokes_ProcessLauncher_To_Install(
+        public void InstallRefitter_When_Refitter_Installed_With_Old_Version_Invokes_ProcessLauncher_To_Update(
             [Frozen] IProcessLauncher processLauncher,
             DependencyInstaller sut)
         {
@@ -219,7 +219,7 @@ namespace ApiClientCodeGen.Core.Tests.Installer
             mock.Verify(
                 c => c.Start(
                     It.IsAny<string>(),
-                    "tool install --global refitter --version 1.7.3",
+                    "tool update --global refitter --version 1.7.3",
                     null),
                 Times.Once);
         }

--- a/src/Core/ApiClientCodeGen.Core/External/PathProvider.cs
+++ b/src/Core/ApiClientCodeGen.Core/External/PathProvider.cs
@@ -69,9 +69,13 @@ namespace Rapicgen.Core.External
                 Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
                 "Rico Suter\\NSwagStudio\\Win\\NSwag.exe");
 
-        public static string GetNSwagPath(bool withoutPath = false)        
-            => GetDotNetGlobalToolPath("nswag");
-        
+        public static string GetNSwagPath(bool withoutPath = false)
+        {
+            if (Environment.OSVersion.Platform is PlatformID.MacOSX or PlatformID.Unix || withoutPath)
+                return "nswag";
+
+            return GetDotNetGlobalToolPath("nswag");
+        }
 
         public static string GetAutoRestPath(bool withoutPath = false)
         {

--- a/src/Core/ApiClientCodeGen.Core/External/PathProvider.cs
+++ b/src/Core/ApiClientCodeGen.Core/External/PathProvider.cs
@@ -111,6 +111,31 @@ namespace Rapicgen.Core.External
                 : Path.Combine(programFiles, "dotnet", "dotnet.exe");
         }
 
+        public static string GetRefitterPath()
+            => GetDotNetGlobalToolPath("refitter");
+
+        public static string GetKiotaPath()
+            => GetDotNetGlobalToolPath("kiota");
+
+        public static string GetDotNetGlobalToolPath(string toolName)
+        {
+            try
+            {
+                var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                var toolsPath = Path.Combine(userProfile, ".dotnet", "tools");
+                var executableName = Environment.OSVersion.Platform is PlatformID.MacOSX or PlatformID.Unix
+                    ? toolName
+                    : $"{toolName}.exe";
+                var fullPath = Path.Combine(toolsPath, executableName);
+                return File.Exists(fullPath) ? fullPath : toolName;
+            }
+            catch (Exception e)
+            {
+                Logger.Instance.TrackError(e);
+                return toolName;
+            }
+        }
+
         private static string GetProgramFiles64bitPath()
         {
             var programFiles = Environment.GetEnvironmentVariable("ProgramW6432");

--- a/src/Core/ApiClientCodeGen.Core/External/PathProvider.cs
+++ b/src/Core/ApiClientCodeGen.Core/External/PathProvider.cs
@@ -69,15 +69,9 @@ namespace Rapicgen.Core.External
                 Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
                 "Rico Suter\\NSwagStudio\\Win\\NSwag.exe");
 
-        public static string GetNSwagPath(bool withoutPath = false)
-        {
-            if (Environment.OSVersion.Platform is PlatformID.MacOSX or PlatformID.Unix || withoutPath)
-                return "nswag";
-
-            return Path.Combine(
-                NpmHelper.GetPrefixPath(),
-                "nswag.cmd");
-        }
+        public static string GetNSwagPath(bool withoutPath = false)        
+            => GetDotNetGlobalToolPath("nswag");
+        
 
         public static string GetAutoRestPath(bool withoutPath = false)
         {

--- a/src/Core/ApiClientCodeGen.Core/Generators/Kiota/KiotaCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/Kiota/KiotaCodeGenerator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using Rapicgen.Core.External;
 using Rapicgen.Core.Installer;
 using Rapicgen.Core.Logging;
 using Rapicgen.Core.Options.Kiota;
@@ -14,7 +15,7 @@ public class KiotaCodeGenerator(
     IKiotaOptions options) : ICodeGenerator
 {
     private const string KiotaLockFile = "kiota-lock.json";
-    private const string Command = "kiota";
+    private const string CommandName = "kiota";
 
     public string GenerateCode(IProgressReporter? pGenerateProgress)
     {
@@ -69,8 +70,8 @@ public class KiotaCodeGenerator(
             pGenerateProgress?.Progress(60);
 
             var arguments = $" update -o \"{outputFolder}\"";
-            using var context = new DependencyContext("Kiota", $"{Command} {arguments}");
-            processLauncher.Start(Command, arguments, outputFolder);
+            using var context = new DependencyContext("Kiota", $"{CommandName} {arguments}");
+            processLauncher.Start(PathProvider.GetKiotaPath(), arguments, outputFolder);
             context.Succeeded();
         }
 
@@ -110,16 +111,16 @@ public class KiotaCodeGenerator(
         if (options.UsesBackingStore)
             arguments += " --backing-store";
 
-        using var context = new DependencyContext("Kiota", $"{Command} {arguments}");
-        processLauncher.Start(Command, arguments);
+        using var context = new DependencyContext("Kiota", $"{CommandName} {arguments}");
+        processLauncher.Start(PathProvider.GetKiotaPath(), arguments);
         context.Succeeded();
     }
 
     private void RunKiotaUpdate()
     {
         var arguments = $" update -o \"{Path.GetDirectoryName(swaggerFile)!}\"";
-        using var context = new DependencyContext("Kiota", $"{Command} {arguments}");
-        processLauncher.Start(Command, arguments);
+        using var context = new DependencyContext("Kiota", $"{CommandName} {arguments}");
+        processLauncher.Start(PathProvider.GetKiotaPath(), arguments);
         context.Succeeded();
     }
 }

--- a/src/Core/ApiClientCodeGen.Core/Generators/NSwag/NSwagCSharpCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/NSwag/NSwagCSharpCodeGenerator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using Rapicgen.Core.External;
 using Rapicgen.Core.Installer;
 using Rapicgen.Core.Logging;
 using Rapicgen.Core.Options.NSwag;
@@ -44,7 +45,7 @@ namespace Rapicgen.Core.Generators.NSwag
             var arguments = BuildNSwagArguments(outputPath, className);
 
             using var context = new DependencyContext("NSwag", $"{Command} {arguments}");
-            processLauncher.Start(Command, arguments, workingDirectory);
+            processLauncher.Start(PathProvider.GetNSwagPath(), arguments, workingDirectory);
             context.Succeeded();
 
             pGenerateProgress?.Progress(80);

--- a/src/Core/ApiClientCodeGen.Core/Generators/Refitter/RefitterCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/Refitter/RefitterCodeGenerator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text.Json;
+using Rapicgen.Core.External;
 using Rapicgen.Core.Installer;
 using Rapicgen.Core.Logging;
 using Rapicgen.Core.Options.Refitter;
@@ -16,7 +17,7 @@ public class RefitterCodeGenerator : ICodeGenerator
     private readonly IProcessLauncher processLauncher;
     private readonly IDependencyInstaller dependencyInstaller;
 
-    private const string Command = "refitter";
+    private const string CommandName = "refitter";
 
     public RefitterCodeGenerator(
         string swaggerFile,
@@ -66,8 +67,8 @@ public class RefitterCodeGenerator : ICodeGenerator
         var arguments = $"--settings-file \"{inputFile}\" --simple-output";
         var workingDirectory = Path.GetDirectoryName(inputFile);
 
-        using var context = new DependencyContext("Refitter", $"{Command} {arguments}");
-        processLauncher.Start(Command, arguments, workingDirectory);
+        using var context = new DependencyContext("Refitter", $"{CommandName} {arguments}");
+        processLauncher.Start(PathProvider.GetRefitterPath(), arguments, workingDirectory);
         context.Succeeded();
 
         pGenerateProgress?.Progress(80);
@@ -111,8 +112,8 @@ public class RefitterCodeGenerator : ICodeGenerator
             var outputDir = workingDirectory;
             var arguments = BuildRefitterArguments(inputFile, outputDir, multipleFiles: true);
 
-            using var context = new DependencyContext("Refitter", $"{Command} {arguments}");
-            processLauncher.Start(Command, arguments, workingDirectory);
+            using var context = new DependencyContext("Refitter", $"{CommandName} {arguments}");
+            processLauncher.Start(PathProvider.GetRefitterPath(), arguments, workingDirectory);
             context.Succeeded();
 
             pGenerateProgress?.Progress(100);
@@ -124,8 +125,8 @@ public class RefitterCodeGenerator : ICodeGenerator
         
         var arguments2 = BuildRefitterArguments(inputFile, outputPath);
 
-        using var ctx = new DependencyContext("Refitter", $"{Command} {arguments2}");
-        processLauncher.Start(Command, arguments2, workingDirectory);
+        using var ctx = new DependencyContext("Refitter", $"{CommandName} {arguments2}");
+        processLauncher.Start(PathProvider.GetRefitterPath(), arguments2, workingDirectory);
         ctx.Succeeded();
 
         pGenerateProgress?.Progress(80);

--- a/src/Core/ApiClientCodeGen.Core/Installer/DependencyInstaller.cs
+++ b/src/Core/ApiClientCodeGen.Core/Installer/DependencyInstaller.cs
@@ -195,9 +195,17 @@ namespace Rapicgen.Core.Installer
                 
                 if (!refitterInstalled || installedVersion == null || installedVersion < requiredVersion)
                 {
-                    // Refitter is not installed or version is too old, install/update required version
                     var installCommand = PathProvider.GetDotNetPath();
-                    var installArguments = "tool install --global refitter --version 1.7.3";
+                    string installArguments;
+                    if (refitterInstalled)
+                    {
+                        // Already installed but outdated — use update
+                        installArguments = "tool update --global refitter --version 1.7.3";
+                    }
+                    else
+                    {
+                        installArguments = "tool install --global refitter --version 1.7.3";
+                    }
                     using var context = new DependencyContext(installCommand, $"{installCommand} {installArguments}");
                     processLauncher.Start(installCommand, installArguments);
                     context.Succeeded();


### PR DESCRIPTION
## Problem

Generating code using Refitter (and Kiota) fails in Visual Studio with:

```
System.ComponentModel.Win32Exception (0x80004005): The system cannot find the file specified
at System.Diagnostics.Process.StartWithCreateProcess(ProcessStartInfo startInfo)
at Rapicgen.Core.Generators.ProcessLauncher.StartInternal(...)
at Rapicgen.Core.Generators.Refitter.RefitterCodeGenerator.GenerateFromSwaggerFile(...)
```

## Root Cause

Visual Studio's host process runs with a restricted `PATH` that does **not** include `%USERPROFILE%\.dotnet\tools\` — the directory where .NET global tools like `refitter` and `kiota` are installed.

Both `RefitterCodeGenerator` and `KiotaCodeGenerator` used bare command names (`"refitter"`, `"kiota"`), so `Process.Start()` could not locate the executable.

By contrast, `NSwagCodeGenerator` correctly uses `PathProvider.GetNSwagPath()` which resolves the full path.

## Fix

- Added `GetDotNetGlobalToolPath(toolName)` to `PathProvider` — resolves the full path to `%USERPROFILE%\.dotnet\tools\{toolName}.exe` on Windows / `~/.dotnet/tools/{toolName}` on Unix, falling back to the bare name if the file doesn't exist
- Added `GetRefitterPath()` and `GetKiotaPath()` convenience wrappers
- Updated `RefitterCodeGenerator` to use `PathProvider.GetRefitterPath()`
- Updated `KiotaCodeGenerator` to use `PathProvider.GetKiotaPath()`
- Fixed secondary bug in `DependencyInstaller.InstallRefitter()`: when refitter is already installed but outdated, now correctly calls `dotnet tool update` instead of `dotnet tool install` (which would fail with an already-installed error)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved discovery and launching of external tools (NSwag, Kiota, Refitter) for more reliable execution across platforms.
* **Bug Fixes / Improvements**
  * Better handling when tool binaries are not found, with robust fallbacks and clearer failure logging.
  * Enhanced Refitter installation logic to update existing outdated installations instead of reinstalling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->