### PR TITLE
Mandate frequent small commits with no co-author for AI agents

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -329,4 +329,10 @@ ls -la dist/extension.js
 The project builds and runs successfully with the above commands. Some tests may fail due to external network dependencies, but the core functionality works correctly.
 
 ## Git
-Commit every logical small change with a brief commit description for a detailed history of a changes
+
+AI agents must follow these commit rules automatically on **all** agentic work, without being prompted:
+
+- **Commit often, in small logical groups.** Make a separate commit for each logical change as soon as it is complete, rather than batching many unrelated changes into one large commit. This keeps a detailed, easy-to-follow progress history.
+- Write a brief, descriptive commit message for each commit that explains the change.
+- **Never add a co-author to commits.** Do not include `Co-authored-by` trailers, and do not attribute commits to any AI agent or assistant. Commit messages must contain only the change description.
+- When a unit of work spans multiple files or phases, prefer several focused commits over a single combined commit.

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -4,6 +4,22 @@
 
 ---
 
+## Decision: User Directives — Frequent Small Commits, Never Add a Co-Author
+
+**Authority:** Christian (User)  
+**Date:** 2026-05-30T01:30:02Z  
+**Status:** Binding  
+
+**Rule:** On all agentic work, commit changes as often as possible in small, logical groups so the history reflects detailed progress. Each logical change gets its own commit with a brief descriptive message. **Never** add a co-author to any commit — do not include `Co-authored-by` trailers or attribute commits to any AI agent or assistant. This applies automatically to all future work without the user having to ask.
+
+**Rationale:** Detailed, granular commit history makes progress easy to follow and review. Commit authorship must reflect only the change, not the tooling.
+
+**Supersedes:** Any prior guidance or QA gate (including earlier OpenAPI Generator update reviews) that required `Co-authored-by` trailers to be present. Co-author trailers are now prohibited.
+
+**Binding on:** All agents, all branches, all tasks.
+
+---
+
 ## Decision: User Directives — No Direct Master Commits, PR Workflow Required
 
 **Authority:** Christian (User)  


### PR DESCRIPTION
## Summary

Updates AI agent instructions so that commit conventions are applied automatically on all future agentic work, without the user having to prompt for them.

## Changes

- **.github/copilot-instructions.md** — Expanded the `## Git` section to require:
  - Committing often, in small logical groups (one commit per logical change) for a detailed progress history.
  - Brief, descriptive commit messages.
  - **Never** adding a co-author (no `Co-authored-by` trailers, no AI/assistant attribution).
- **.squad/decisions.md** — Added a binding user directive recording the same rule and explicitly superseding earlier QA gates that required `Co-authored-by` trailers.

## Notes

The Squad decisions previously treated co-author trailers as a required QA gate; this PR reverses that so co-authors are now prohibited.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established standardized commit practices and guidelines to ensure consistent, focused commits with clear messaging in automated development workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/christianhelle/apiclientcodegen/pull/1590?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->