### PR TITLE
Always show the "Generate with ..." context menus in the item node

### DIFF
--- a/src/VSIX/ApiClientCodeGen.VSIX.Extensibility/Commands/AutoRestCommands.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Extensibility/Commands/AutoRestCommands.cs
@@ -20,7 +20,7 @@ public class GenerateAutoRestCommand(TraceSource traceSource, ExtensionSettingsP
         => new("%AutoRestCommand.DisplayName%")
         {
             Icon = new(ImageMoniker.KnownValues.GenerateFile, IconSettings.IconAndText),
-            VisibleWhen = ActivationConstraint.ClientContext(ClientContextKey.Shell.ActiveSelectionFileName, ".(json|ya?ml)")
+            //VisibleWhen = ActivationConstraint.ClientContext(ClientContextKey.Shell.ActiveSelectionFileName, ".(json|ya?ml)")
         };
 
     public override async Task ExecuteCommandAsync(

--- a/src/VSIX/ApiClientCodeGen.VSIX.Extensibility/Commands/KiotaCommands.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Extensibility/Commands/KiotaCommands.cs
@@ -17,7 +17,7 @@ public class GenerateKiotaCommand(TraceSource traceSource, ExtensionSettingsProv
     public override CommandConfiguration CommandConfiguration => new("%KiotaCommand.DisplayName%")
     {
         Icon = new(ImageMoniker.KnownValues.GenerateFile, IconSettings.IconAndText),
-        VisibleWhen = ActivationConstraint.ClientContext(ClientContextKey.Shell.ActiveSelectionFileName, ".(json|ya?ml)")
+        //VisibleWhen = ActivationConstraint.ClientContext(ClientContextKey.Shell.ActiveSelectionFileName, ".(json|ya?ml)")
     };
 
     public override async Task ExecuteCommandAsync(

--- a/src/VSIX/ApiClientCodeGen.VSIX.Extensibility/Commands/NSwagCommands.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Extensibility/Commands/NSwagCommands.cs
@@ -23,7 +23,7 @@ public class GenerateNSwagCommand(TraceSource traceSource, ExtensionSettingsProv
     public override CommandConfiguration CommandConfiguration => new("%NSwagCommand.DisplayName%")
     {
         Icon = new(ImageMoniker.KnownValues.GenerateFile, IconSettings.IconAndText),
-        VisibleWhen = ActivationConstraint.ClientContext(ClientContextKey.Shell.ActiveSelectionFileName, ".(json|ya?ml)")
+        //VisibleWhen = ActivationConstraint.ClientContext(ClientContextKey.Shell.ActiveSelectionFileName, ".(json|ya?ml)")
     };
 
     public override async Task ExecuteCommandAsync(
@@ -48,9 +48,7 @@ public class GenerateNSwagStudioCommand(
     {
         Icon = new(ImageMoniker.KnownValues.GenerateFile, IconSettings.IconAndText),
         Placements = [KnownPlacements.Node_IncludeExcludeGroup],
-        VisibleWhen = ActivationConstraint.ClientContext(
-            ClientContextKey.Shell.ActiveSelectionFileName,
-            ".(nswag)")
+        //VisibleWhen = ActivationConstraint.ClientContext(ClientContextKey.Shell.ActiveSelectionFileName, ".(nswag)")
     };
 
     public override async Task ExecuteCommandAsync(

--- a/src/VSIX/ApiClientCodeGen.VSIX.Extensibility/Commands/OpenApiGeneratorCommands.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Extensibility/Commands/OpenApiGeneratorCommands.cs
@@ -17,7 +17,7 @@ public class GenerateOpenApiCommand(TraceSource traceSource, ExtensionSettingsPr
     public override CommandConfiguration CommandConfiguration => new("%OpenApiGeneratorCommand.DisplayName%")
     {
         Icon = new(ImageMoniker.KnownValues.GenerateFile, IconSettings.IconAndText),
-        VisibleWhen = ActivationConstraint.ClientContext(ClientContextKey.Shell.ActiveSelectionFileName, ".(json|ya?ml)")
+        //VisibleWhen = ActivationConstraint.ClientContext(ClientContextKey.Shell.ActiveSelectionFileName, ".(json|ya?ml)")
     };
 
     public override async Task ExecuteCommandAsync(

--- a/src/VSIX/ApiClientCodeGen.VSIX.Extensibility/Commands/RefitterCommands.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Extensibility/Commands/RefitterCommands.cs
@@ -19,7 +19,7 @@ public class GenerateRefitterCommand(TraceSource traceSource, ExtensionSettingsP
         => new("%RefitterCommand.DisplayName%")
         {
             Icon = new(ImageMoniker.KnownValues.GenerateFile, IconSettings.IconAndText),
-            VisibleWhen = ActivationConstraint.ClientContext(ClientContextKey.Shell.ActiveSelectionFileName, ".(json|ya?ml)")
+            //VisibleWhen = ActivationConstraint.ClientContext(ClientContextKey.Shell.ActiveSelectionFileName, ".(json|ya?ml)")
         };
 
     public override async Task ExecuteCommandAsync(
@@ -43,9 +43,7 @@ public class GenerateRefitterSettingsCommand(TraceSource traceSource, ExtensionS
         {
             Icon = new(ImageMoniker.KnownValues.GenerateFile, IconSettings.IconAndText),
             Placements = [KnownPlacements.Node_IncludeExcludeGroup],
-            VisibleWhen = ActivationConstraint.ClientContext(
-                ClientContextKey.Shell.ActiveSelectionFileName,
-                ".(refitter)")
+            //VisibleWhen = ActivationConstraint.ClientContext(ClientContextKey.Shell.ActiveSelectionFileName, ".(refitter)")
         };
 
     public override async Task ExecuteCommandAsync(

--- a/src/VSIX/ApiClientCodeGen.VSIX.Extensibility/Commands/SwaggerCodegenCommands.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Extensibility/Commands/SwaggerCodegenCommands.cs
@@ -17,7 +17,7 @@ public class GenerateSwaggerCommand(TraceSource traceSource, ExtensionSettingsPr
     public override CommandConfiguration CommandConfiguration => new("%SwaggerCommand.DisplayName%")
     {
         Icon = new(ImageMoniker.KnownValues.GenerateFile, IconSettings.IconAndText),
-        VisibleWhen = ActivationConstraint.ClientContext(ClientContextKey.Shell.ActiveSelectionFileName, ".(json|ya?ml)")
+        //VisibleWhen = ActivationConstraint.ClientContext(ClientContextKey.Shell.ActiveSelectionFileName, ".(json|ya?ml)")
     };
 
     public override async Task ExecuteCommandAsync(


### PR DESCRIPTION
In the VSIX version that uses the new VS Extensibility Model. This is a temporary solution until I figure out why the VisibleWhen property is not respected

This temporarily fixes #1593 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed file type restrictions from multiple code generation commands (AutoRest, Kiota, NSwag, OpenAPI Generator, Refitter, and Swagger Codegen). These commands are now available in the IDE without requiring specific files to be selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->