### PR TITLE
Migrate from deprecated kotlinOptions to compilerOptions DSL

### DIFF
--- a/src/IntelliJ/build.gradle.kts
+++ b/src/IntelliJ/build.gradle.kts
@@ -44,9 +44,9 @@ dependencies {
 }
 
 tasks {
-    withType<JavaCompile> { sourceCompatibility = javaVersion; targetCompatibility = javaVersion }
-    withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-        kotlinOptions { jvmTarget = javaVersion }
+    withType<JavaCompile> {
+        sourceCompatibility = javaVersion
+        targetCompatibility = javaVersion
     }
     buildPlugin {
         // JARs inside the plugin ZIP must be STORED (not compressed) so IntelliJ's
@@ -57,6 +57,9 @@ tasks {
 
 kotlin {
     jvmToolchain(javaVersion.toInt())
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.valueOf("JVM_${javaVersion}"))
+    }
 }
 
 java {

--- a/src/IntelliJ/gradle.properties
+++ b/src/IntelliJ/gradle.properties
@@ -7,7 +7,7 @@ platformVersion=2025.1
 platformPlugins=
 javaVersion=21
 gradleVersion=8.7
-org.gradle.jvmargs=-Xmx2g
+org.gradle.jvmargs=-Xmx2g -Djansi.ignore=true
 org.gradle.java.installations.auto-download=true
 org.gradle.java.installations.auto-detect=true
 kotlin.stdlib.default.dependency=false

--- a/src/IntelliJ/src/main/resources/META-INF/plugin.xml
+++ b/src/IntelliJ/src/main/resources/META-INF/plugin.xml
@@ -4,7 +4,7 @@
     <name>REST API Client Code Generator</name>
     <vendor url="https://github.com/christianhelle/apiclientcodegen">Christian Resma Helle</vendor>
     <description><![CDATA[
-        <h2>🚀 REST API Client Code Generator</h2>
+        <h2>[REST API Client Code Generator]</h2>
         
         <p><strong>Streamline your API integration workflow</strong> by automatically generating type-safe, production-ready REST API clients directly from OpenAPI/Swagger specifications. This plugin brings the power of industry-leading code generators right into your JetBrains IDE.</p>
         


### PR DESCRIPTION
## Problem 1: Kotlin 2.3.21 deprecated API

The IntelliJ plugin build fails because \kotlinOptions { jvmTarget = ... }\ is deprecated and removed in Kotlin 2.3.21.

## Fix 1

- Remove deprecated \withType<KotlinCompile>\ block
- Add \compilerOptions { jvmTarget.set(...) }\ to the \kotlin {}\ block

---

## Problem 2: Harmless OutOfMemoryError on Windows

After build success, Gradle's Jansi library throws \OutOfMemoryError: Java heap space\ in a cleanup thread when the extracted JDK folder has many files. This is harmless but alarming to users.

## Fix 2

- Add \-Djansi.ignore=true\ to \org.gradle.jvmargs\ in gradle.properties

---

## Problem 3: verifyPlugin fails on emoji in description

The \erifyPlugin\ task fails with:

\\\
Invalid plugin descriptor 'description'. The plugin description must start with Latin characters and have at least 40 characters.
\\\

The description in \plugin.xml\ starts with \<h2>🚀 REST API...</h2>\ - the emoji \🚀\ is not a Latin character.

## Fix 3

- Replace \🚀\ with \[REST]\ in the first line of the description