### PR TITLE
Add explicit support for OpenAPI configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ A collection of Visual Studio C# custom tool code generators for Swagger / OpenA
   - `.refitter` settings files from [Refitter](https://github.com/christianhelle/refitter) by including it in the project and using the **Generate Refitter output** context menu
   - `kiota-lock.json` configuration files from [Microsoft Kiota](https://github.com/microsoft/kiota) by including it in the project and using the **Generate Kiota output** context menu
 
+### OpenAPI Generator configuration files
+
+For the `rapicgen csharp openapi` command, you can now pass `--config-file <path>` to use a specific OpenAPI Generator configuration file. When no explicit file is supplied, Rapicgen also auto-discovers adjacent files named `<spec>.config.<ext>`, `<spec>.config.json`, and `<spec>.config.yaml` when `--use-configuration-file` is enabled. This makes it easier to drive package name, output layout, project format, and similar OpenAPI Generator options from configuration rather than relying only on the defaults.
+
 ### Custom Tools
 
 Custom tools let you associate a tool with an item in a project and run that tool whenever the file is saved

--- a/src/CLI/ApiClientCodeGen.CLI/Commands/CSharp/OpenApiCSharpGeneratorCommand.cs
+++ b/src/CLI/ApiClientCodeGen.CLI/Commands/CSharp/OpenApiCSharpGeneratorCommand.cs
@@ -57,6 +57,10 @@ namespace Rapicgen.CLI.Commands.CSharp
         [Description("Path to directory containing additional mustache template files")]
         public string? TemplatesPath { get; set; }
 
+        [CommandOption("--config-file")]
+        [Description("Path to an OpenAPI Generator configuration file to use instead of auto-discovery")]
+        public string? ConfigurationFile { get; set; }
+
         [CommandOption("--use-configuration-file")]
         [Description("Use the configuration file if present")]
         public bool UseConfigurationFile { get; set; } = true;

--- a/src/Core/ApiClientCodeGen.Core.Tests/Generators/OpenApi/OpenApiCSharpCodeGeneratorTests.cs
+++ b/src/Core/ApiClientCodeGen.Core.Tests/Generators/OpenApi/OpenApiCSharpCodeGeneratorTests.cs
@@ -1,9 +1,17 @@
-﻿using ApiClientCodeGen.Tests.Common;
+using System;
+using System.IO;
+using ApiClientCodeGen.Tests.Common;
 using ApiClientCodeGen.Tests.Common.Infrastructure;
 using AutoFixture.Xunit2;
-using Rapicgen.Core;
-using Rapicgen.Core.Generators.OpenApi;
 using Moq;
+using Rapicgen.Core;
+using Rapicgen.Core.External;
+using Rapicgen.Core.Generators;
+using Rapicgen.Core.Generators.OpenApi;
+using Rapicgen.Core.Installer;
+using Rapicgen.Core.Options.General;
+using Rapicgen.Core.Options.OpenApiGenerator;
+using Rapicgen.Core.Extensions;
 using Xunit;
 
 namespace ApiClientCodeGen.Core.Tests.Generators.OpenApi
@@ -22,6 +30,61 @@ namespace ApiClientCodeGen.Core.Tests.Generators.OpenApi
                         It.IsAny<uint>(),
                         It.IsAny<uint>()),
                     Times.Exactly(5));
+        }
+
+        [Fact]
+        public void GenerateCode_Uses_Explicit_Configuration_File_When_Specified()
+        {
+            var tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDirectory);
+
+            try
+            {
+                var swaggerFile = Path.Combine(tempDirectory, "petstore.yaml");
+                File.WriteAllText(swaggerFile, "openapi: 3.0.0");
+
+                var configFile = Path.Combine(tempDirectory, "petstore.config.yaml");
+                File.WriteAllText(configFile, "generatorName: csharp");
+
+                var version = OpenApiSupportedVersion.V7230;
+                var jarFile = Path.Combine(Path.GetTempPath(), $"openapi-generator-cli-{version.GetDescription()}.jar");
+                File.WriteAllText(jarFile, "jar");
+
+                var processLauncher = new Mock<IProcessLauncher>();
+                var dependencyInstaller = new Mock<IDependencyInstaller>();
+                var options = new DefaultGeneralOptions();
+                var openApiGeneratorOptions = new DefaultOpenApiGeneratorOptions
+                {
+                    Version = version,
+                    ConfigurationFile = configFile,
+                    UseConfigurationFile = false
+                };
+
+                var sut = new OpenApiCSharpCodeGenerator(
+                    swaggerFile,
+                    "GeneratedCode",
+                    options,
+                    openApiGeneratorOptions,
+                    processLauncher.Object,
+                    dependencyInstaller.Object);
+
+                sut.GenerateCode(null);
+
+                processLauncher.Verify(
+                    p => p.Start(
+                        It.IsAny<string>(),
+                        It.Is<string>(arguments => arguments.Contains($"-c \"{configFile}\"")),
+                        It.IsAny<string?>()),
+                    Times.Once);
+            }
+            finally
+            {
+                Directory.Delete(tempDirectory, recursive: true);
+                if (File.Exists(Path.Combine(Path.GetTempPath(), $"openapi-generator-cli-{OpenApiSupportedVersion.V7230.GetDescription()}.jar")))
+                {
+                    File.Delete(Path.Combine(Path.GetTempPath(), $"openapi-generator-cli-{OpenApiSupportedVersion.V7230.GetDescription()}.jar"));
+                }
+            }
         }
     }
 }

--- a/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiCSharpCodeGenerator.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/OpenApi/OpenApiCSharpCodeGenerator.cs
@@ -76,7 +76,18 @@ namespace Rapicgen.Core.Generators.OpenApi
                     arguments += $"--http-user-agent \"{openApiGeneratorOptions.HttpUserAgent}\" ";
                 }
 
-                if (openApiGeneratorOptions.UseConfigurationFile)
+                if (!string.IsNullOrWhiteSpace(openApiGeneratorOptions.ConfigurationFile))
+                {
+                    var configFile = openApiGeneratorOptions.ConfigurationFile;
+                    if (!Path.IsPathRooted(configFile))
+                    {
+                        var swaggerDirectory = Path.GetDirectoryName(swaggerFile) ?? Directory.GetCurrentDirectory();
+                        configFile = Path.GetFullPath(Path.Combine(swaggerDirectory, configFile));
+                    }
+
+                    arguments += $"-c \"{configFile}\" ";
+                }
+                else if (openApiGeneratorOptions.UseConfigurationFile)
                 {
                     var extension = Path.GetExtension(swaggerFile);
                     if (extension != null)

--- a/src/Core/ApiClientCodeGen.Core/Options/OpenApiGenerator/DefaultOpenApiGeneratorOptions.cs
+++ b/src/Core/ApiClientCodeGen.Core/Options/OpenApiGenerator/DefaultOpenApiGeneratorOptions.cs
@@ -23,6 +23,8 @@ namespace Rapicgen.Core.Options.OpenApiGenerator
 
         public string? TemplatesPath { get; set; }
 
+        public string? ConfigurationFile { get; set; }
+
         public bool UseConfigurationFile { get; set; } = false;
 
         public bool GenerateMultipleFiles { get; set; }

--- a/src/Core/ApiClientCodeGen.Core/Options/OpenApiGenerator/IOpenApiGeneratorOptions.cs
+++ b/src/Core/ApiClientCodeGen.Core/Options/OpenApiGenerator/IOpenApiGeneratorOptions.cs
@@ -11,6 +11,7 @@
         string? CustomAdditionalProperties { get; set; }
         bool SkipFormModel { get; set; }
         string? TemplatesPath { get; set; }
+        string? ConfigurationFile { get; set; }
         bool UseConfigurationFile { get; set; }
         bool GenerateMultipleFiles { get; set; }
         public OpenApiSupportedVersion Version { get; set; }

--- a/src/VSIX/ApiClientCodeGen.VSIX.Extensibility/Settings/ExtensionSettingsProvider.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Extensibility/Settings/ExtensionSettingsProvider.cs
@@ -102,6 +102,7 @@ public class ExtensionSettingsProvider(VisualStudioExtensibility extensibility)
             OpenApiGeneratorSettings.OpenApiCustomAdditionalProperties,
             OpenApiGeneratorSettings.OpenApiSkipFormModel,
             OpenApiGeneratorSettings.OpenApiTemplatesPath,
+            OpenApiGeneratorSettings.OpenApiConfigurationFile,
             OpenApiGeneratorSettings.OpenApiUseConfigurationFile,
             OpenApiGeneratorSettings.OpenApiGenerateMultipleFiles,
             OpenApiGeneratorSettings.OpenApiVersion,
@@ -220,7 +221,7 @@ public class ExtensionSettingsProvider(VisualStudioExtensibility extensibility)
             = NormalizeEmpty(values.ValueOrDefault(OpenApiGeneratorSettings.OpenApiCustomAdditionalProperties, string.Empty));
         public bool SkipFormModel { get; set; } = values.ValueOrDefault(OpenApiGeneratorSettings.OpenApiSkipFormModel, true);
         public string? TemplatesPath { get; set; } = NormalizeEmpty(values.ValueOrDefault(OpenApiGeneratorSettings.OpenApiTemplatesPath, string.Empty));
-        public string? ConfigurationFile { get; set; }
+        public string? ConfigurationFile { get; set; } = NormalizeEmpty(values.ValueOrDefault(OpenApiGeneratorSettings.OpenApiConfigurationFile, string.Empty));
         public bool UseConfigurationFile { get; set; } = values.ValueOrDefault(OpenApiGeneratorSettings.OpenApiUseConfigurationFile, true);
         public bool GenerateMultipleFiles { get; set; } = values.ValueOrDefault(OpenApiGeneratorSettings.OpenApiGenerateMultipleFiles, false);
         public OpenApiSupportedVersion Version { get; set; }

--- a/src/VSIX/ApiClientCodeGen.VSIX.Extensibility/Settings/ExtensionSettingsProvider.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Extensibility/Settings/ExtensionSettingsProvider.cs
@@ -220,6 +220,7 @@ public class ExtensionSettingsProvider(VisualStudioExtensibility extensibility)
             = NormalizeEmpty(values.ValueOrDefault(OpenApiGeneratorSettings.OpenApiCustomAdditionalProperties, string.Empty));
         public bool SkipFormModel { get; set; } = values.ValueOrDefault(OpenApiGeneratorSettings.OpenApiSkipFormModel, true);
         public string? TemplatesPath { get; set; } = NormalizeEmpty(values.ValueOrDefault(OpenApiGeneratorSettings.OpenApiTemplatesPath, string.Empty));
+        public string? ConfigurationFile { get; set; }
         public bool UseConfigurationFile { get; set; } = values.ValueOrDefault(OpenApiGeneratorSettings.OpenApiUseConfigurationFile, true);
         public bool GenerateMultipleFiles { get; set; } = values.ValueOrDefault(OpenApiGeneratorSettings.OpenApiGenerateMultipleFiles, false);
         public OpenApiSupportedVersion Version { get; set; }

--- a/src/VSIX/ApiClientCodeGen.VSIX.Extensibility/Settings/OpenApiGeneratorSettings.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Extensibility/Settings/OpenApiGeneratorSettings.cs
@@ -115,6 +115,16 @@ internal static class OpenApiGeneratorSettings
     };
 
     [VisualStudioContribution]
+    internal static Setting.String OpenApiConfigurationFile { get; } = new(
+        "configurationFile",
+        "%Settings.OpenApi.ConfigurationFile.DisplayName%",
+        OpenApiGeneratorCategory,
+        string.Empty)
+    {
+        Description = "%Settings.OpenApi.ConfigurationFile.Description%",
+    };
+
+    [VisualStudioContribution]
     internal static Setting.Boolean OpenApiUseConfigurationFile { get; } = new(
         "useConfigurationFile",
         "%Settings.OpenApi.UseConfigurationFile.DisplayName%",

--- a/src/VSIX/ApiClientCodeGen.VSIX.Shared/Options/OpenApiGenerator/OpenApiGeneratorOptions.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Shared/Options/OpenApiGenerator/OpenApiGeneratorOptions.cs
@@ -24,6 +24,7 @@ namespace Rapicgen.Options.OpenApiGenerator
                 CustomAdditionalProperties = options.CustomAdditionalProperties;
                 SkipFormModel = options.SkipFormModel;
                 TemplatesPath = options.TemplatesPath;
+                ConfigurationFile = options.ConfigurationFile;
                 UseConfigurationFile = options.UseConfigurationFile;
                 GenerateMultipleFiles = options.GenerateMultipleFiles;
                 HttpUserAgent = options.HttpUserAgent;
@@ -43,6 +44,7 @@ namespace Rapicgen.Options.OpenApiGenerator
                 Logger.Instance.WriteLine($"CustomAdditionalProperties = {CustomAdditionalProperties}");
                 Logger.Instance.WriteLine($"SkipFormModel = {SkipFormModel}");
                 Logger.Instance.WriteLine($"TemplatesPath = {TemplatesPath}");
+                Logger.Instance.WriteLine($"ConfigurationFile = {ConfigurationFile}");
                 Logger.Instance.WriteLine($"UseConfigurationFile = {UseConfigurationFile}");
                 Logger.Instance.WriteLine($"GenerateMultipleFiles = {GenerateMultipleFiles}");
                 Logger.Instance.WriteLine($"HttpUserAgent = {HttpUserAgent}");
@@ -60,6 +62,7 @@ namespace Rapicgen.Options.OpenApiGenerator
         public string? CustomAdditionalProperties { get; set; }
         public bool SkipFormModel { get; set; }
         public string? TemplatesPath { get; set; }
+        public string? ConfigurationFile { get; set; }
         public bool UseConfigurationFile { get; set; }
         public bool GenerateMultipleFiles { get; set; }
         public OpenApiSupportedVersion Version { get; set; }

--- a/src/VSIX/ApiClientCodeGen.VSIX.Shared/Options/OpenApiGenerator/OpenApiGeneratorOptionsPage.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Shared/Options/OpenApiGenerator/OpenApiGeneratorOptionsPage.cs
@@ -61,6 +61,11 @@ namespace Rapicgen.Options.OpenApiGenerator
         public string? TemplatesPath { get; set; } = null!;
 
         [Category(Name)]
+        [DisplayName("Configuration File")]
+        [Description("Optional path to an OpenAPI Generator configuration file. When set, the generator uses this file instead of auto-discovering one next to the swagger file.")]
+        public string? ConfigurationFile { get; set; } = null!;
+
+        [Category(Name)]
         [DisplayName("Use Configuration File")]
         [Description("Use the configuration file if present.")]
         public bool UseConfigurationFile { get; set; } = true;


### PR DESCRIPTION
This pull request adds support for specifying an explicit OpenAPI Generator configuration file when generating C# code from OpenAPI specs, and improves configuration file handling throughout the codebase. The changes also update the documentation and add tests to ensure correct behavior.

**OpenAPI Generator configuration file support:**

* Added a new `--config-file` option to the CLI (`OpenApiCSharpGeneratorCommandSettings`) to allow users to specify an explicit OpenAPI Generator configuration file path.
* Updated the generator logic (`OpenApiCSharpCodeGenerator`) to prioritize the explicit configuration file if provided, falling back to auto-discovery only if not specified.
* Extended the generator options interfaces and implementations (`IOpenApiGeneratorOptions`, `DefaultOpenApiGeneratorOptions`, `OpenApiGeneratorOptionsPage`, and VSIX settings) to support the new `ConfigurationFile` property. [[1]](diffhunk://#diff-fb1dbc24378e7f0f64fb9fbbfc8a1a2e9c4f07ab957afd6332aa54477fa0fe87R14) [[2]](diffhunk://#diff-9362cbb16b83b5c44a275c0a6e9de06119e81e6d19b116edfd1e4f245ee3706aR26-R27) [[3]](diffhunk://#diff-fdb52f861814fcb91b61b97d4907f5e295153f3080ed77e6e5180159e891b150R63-R67) [[4]](diffhunk://#diff-9e28323b8ced212bbd6480ffefebdd58a8b1d4a824c87a57f2239199b074b5d7R223)

**Testing and documentation:**

* Added a test to ensure that the explicit configuration file is used when specified (`OpenApiCSharpCodeGeneratorTests`).
* Updated the `README.md` to document the new `--config-file` option and explain the auto-discovery mechanism for configuration files.

**Code quality:**

* Minor improvements to test imports and organization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--config-file <path>` option to explicitly provide an OpenAPI Generator configuration file (takes precedence over auto-discovery).
  * Added a “Configuration File” option to the Visual Studio extension to override auto-discovery.
* **Documentation**
  * Updated README to describe `--config-file` and the auto-discovery naming patterns: `<spec>.config.<ext>`, `<spec>.config.json`, `<spec>.config.yaml`.
* **Tests**
  * Added coverage to verify the generator uses the explicitly provided configuration file and passes it to the OpenAPI Generator invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->