### PR TITLE
Filter files before copying in CSharpFileMerger

### DIFF
--- a/src/Core/ApiClientCodeGen.Core/Generators/CSharpFileMerger.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/CSharpFileMerger.cs
@@ -139,8 +139,9 @@ namespace Rapicgen.Core.Generators
 
         private static Func<string, bool> Predicate()
         {
-            return file => file.EndsWith(".cs") &&
-                           !file.Contains("AssemblyInfo.cs");
+            return file => file.EndsWith(".cs", StringComparison.OrdinalIgnoreCase) &&
+                           !file.Contains("AssemblyInfo.cs", StringComparison.OrdinalIgnoreCase) &&
+                           !file.EndsWith("Tests.cs", StringComparison.OrdinalIgnoreCase);
         }
 
 
@@ -205,14 +206,14 @@ namespace Rapicgen.Core.Generators
         {
             using var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
             using var streamReader = new StreamReader(fileStream);
-            
+
             var lines = new List<string>();
             string? line;
             while ((line = streamReader.ReadLine()) != null)
             {
                 lines.Add(line);
             }
-            
+
             return lines.ToArray();
         }
 

--- a/src/Core/ApiClientCodeGen.Core/Generators/CSharpFileMerger.cs
+++ b/src/Core/ApiClientCodeGen.Core/Generators/CSharpFileMerger.cs
@@ -63,7 +63,7 @@ namespace Rapicgen.Core.Generators
                 Directory.CreateDirectory(destFolder);
 
             var files = Directory.GetFiles(srcFolder);
-            foreach (var file in files)
+            foreach (var file in files.Where(Predicate()))
             {
                 var name = Path.GetFileName(file);
                 var dest = Path.Combine(destFolder, name);


### PR DESCRIPTION
Fixes #1595

Filter files before copying in CSharpFileMerger

Only copy files from srcFolder to destFolder that match a specified predicate, instead of copying all files. This adds a filtering condition to the file copy operation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code generation folder/file merging to include only source files that match the configured filtering rules.
  * Updated filtering to be case-insensitive for C# files and to exclude common non-target files (including `AssemblyInfo.cs` and `Tests.cs`), resulting in more accurate generated outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->