### PR TITLE
OpenAPI Generator v7.24.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Custom tools let you associate a tool with an item in a project and run that too
 
 - ***NSwagCodeGenerator*** - Generates a single file C# REST API Client using the [NSwag.CodeGeneration.CSharp](https://github.com/RSuter/NSwag/wiki/CSharpClientGenerator) [nuget package](https://www.nuget.org/packages/NSwag.CodeGeneration.CSharp/) **v14.7.1**
 
-- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **[OpenAPI Generator v7.23.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.23.0)**.
+- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **[OpenAPI Generator v7.24.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.24.0)**.
 The output file is the result of merging all the files generated using the OpenAPI Generator tool with:
 `generate -g csharp --input-spec [swagger file] --output [output file] -DapiTests=false -DmodelTests=false -DpackageName=[default namespace] --skip-overwrite`. It is possible to configure the OpenAPI Generator to generate multiple files which will be placed at the same path as the OpenAPI specifications document that was used to generate code, this is done under Tools -> REST API Client Code Generator -> OpenAPI Generator and setting **Generate Multiple Files** to **true**
 
@@ -352,7 +352,7 @@ Options:
 Commands:
   csharp             Generate C# API clients
   jmeter             Generate Apache JMeter test plans
-  openapi-generator  Generate code using OpenAPI Generator (v7.23.0).
+  openapi-generator  Generate code using OpenAPI Generator (v7.24.0).
                      See supported generators at https://openapi-generator.tech/docs/generators/
   typescript         Generate TypeScript API clients
 
@@ -390,7 +390,7 @@ Options:
 Commands:
   kiota         Microsoft Kiota (v1.34.1)
   nswag         NSwag (v14.7.1)
-  openapi       OpenAPI Generator (v7.23.0)
+  openapi       OpenAPI Generator (v7.24.0)
   refitter      Refitter (v2.0.0)
   swagger       Swagger Codegen CLI (v3.0.34)
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -32,7 +32,7 @@ Options:
 Commands:
   csharp             Generate C# API clients
   jmeter             Generate Apache JMeter test plans
-  openapi-generator  Generate code using OpenAPI Generator (v7.23.0).
+  openapi-generator  Generate code using OpenAPI Generator (v7.24.0).
                      See supported generators at https://openapi-generator.tech/docs/generators/
   typescript         Generate TypeScript API clients
 
@@ -70,7 +70,7 @@ Options:
 Commands:
   kiota         Microsoft Kiota (v1.34.1)
   nswag         NSwag (v14.7.1)
-  openapi       OpenAPI Generator (v7.23.0)
+  openapi       OpenAPI Generator (v7.24.0)
   refitter      Refitter (v2.0.0)
   swagger       Swagger Codegen CLI (v3.0.34)
 

--- a/docs/Marketplace.md
+++ b/docs/Marketplace.md
@@ -26,7 +26,7 @@ A collection of Visual Studio C# custom tool code generators for Swagger / OpenA
 
 - ***NSwagCodeGenerator*** - Generates a single file C# REST API Client using the [NSwag.CodeGeneration.CSharp](https://github.com/RSuter/NSwag/wiki/CSharpClientGenerator) [nuget package](https://www.nuget.org/packages/NSwag.CodeGeneration.CSharp/) **v14.7.1**
 
-- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **[OpenAPI Generator v7.23.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.23.0)**.
+- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **[OpenAPI Generator v7.24.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.24.0)**.
 The output file is the result of merging all the files generated using the OpenAPI Generator tool with:
 `generate -g csharp --input-spec [swagger file] --output [output file] -DapiTests=false -DmodelTests=false -DpackageName=[default namespace] --skip-overwrite`. It is possible to configure the OpenAPI Generator to generate multiple files which will be placed at the same path as the OpenAPI specifications document that was used to generate code, this is done under Tools -> REST API Client Code Generator -> OpenAPI Generator and setting **Generate Multiple Files** to **true**
 

--- a/docs/Marketplace2022.md
+++ b/docs/Marketplace2022.md
@@ -26,7 +26,7 @@ A collection of Visual Studio C# custom tool code generators for Swagger / OpenA
 
 - ***NSwagCodeGenerator*** - Generates a single file C# REST API Client using the [NSwag.CodeGeneration.CSharp](https://github.com/RSuter/NSwag/wiki/CSharpClientGenerator) [nuget package](https://www.nuget.org/packages/NSwag.CodeGeneration.CSharp/) **v14.7.1**
 
-- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **[OpenAPI Generator v7.23.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.23.0)**.
+- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **[OpenAPI Generator v7.24.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.24.0)**.
 The output file is the result of merging all the files generated using the OpenAPI Generator tool with:
 `generate -g csharp --input-spec [swagger file] --output [output file] -DapiTests=false -DmodelTests=false -DpackageName=[default namespace] --skip-overwrite`. It is possible to configure the OpenAPI Generator to generate multiple files which will be placed at the same path as the OpenAPI specifications document that was used to generate code, this is done under Tools -> REST API Client Code Generator -> OpenAPI Generator and setting **Generate Multiple Files** to **true**
 

--- a/docs/VisualStudioForMac.md
+++ b/docs/VisualStudioForMac.md
@@ -13,7 +13,7 @@ A collection of Visual Studio C# custom tool code generators for Swagger / OpenA
 
 - ***NSwagCodeGenerator*** - Generates a single file C# REST API Client using the [NSwag.CodeGeneration.CSharp](https://github.com/RSuter/NSwag/wiki/CSharpClientGenerator) [nuget package](https://www.nuget.org/packages/NSwag.CodeGeneration.CSharp/) **v14.7.1**
 
-- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **[OpenAPI Generator v7.23.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.23.0)**.
+- ***OpenApiCodeGenerator*** - Generates a single file C# REST API Client using **[OpenAPI Generator v7.24.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.24.0)**.
 The output file is the result of merging all the files generated using the OpenAPI Generator tool with:
 `generate -g csharp --input-spec [swagger file] --output [output file] -DapiTests=false -DmodelTests=false -DpackageName=[default namespace] --skip-overwrite`
 

--- a/docs/website/cli.html
+++ b/docs/website/cli.html
@@ -124,7 +124,7 @@ Options:
 Commands:
   csharp             Generate C# API clients
   jmeter             Generate Apache JMeter test plans
-  openapi-generator  Generate code using OpenAPI Generator (v7.23.0).
+  openapi-generator  Generate code using OpenAPI Generator (v7.24.0).
                      See supported generators at https://openapi-generator.tech/docs/generators/
   typescript         Generate TypeScript API clients
 
@@ -147,7 +147,7 @@ Options:
 Commands:
   kiota         Microsoft Kiota (v1.34.1)
   nswag         NSwag (v14.7.1)
-  openapi       OpenAPI Generator (v7.23.0)
+  openapi       OpenAPI Generator (v7.24.0)
   refitter      Refitter (v2.0.0)
   swagger       Swagger Codegen CLI (v3.0.34)
 

--- a/docs/website/features.html
+++ b/docs/website/features.html
@@ -112,7 +112,7 @@
 
           <div class="card">
             <h3>OpenApiCodeGenerator</h3>
-            <p><strong>Version:</strong> v7.23.0</p>
+            <p><strong>Version:</strong> v7.24.0</p>
             <p>Generates a single file C# REST API Client using OpenAPI Generator. The output file merges all generated files using the command: <code>generate -g csharp --input-spec [swagger file] --output [output file] -DapiTests=false -DmodelTests=false -DpackageName=[namespace] --skip-overwrite</code></p>
             <div class="config-section">
               <h4>Configuration Options:</h4>

--- a/docs/website/index.html
+++ b/docs/website/index.html
@@ -145,7 +145,7 @@
           
           <div class="card">
             <h3>OpenAPI Generator</h3>
-            <p><strong>Version:</strong> v7.23.0</p>
+            <p><strong>Version:</strong> v7.24.0</p>
             <p>Uses OpenAPI Generator to create comprehensive client libraries with extensive customization options. Supports multiple output formats and advanced configuration through additional properties.</p>
             <p><strong>Dependencies:</strong> RestSharp, JsonSubTypes, Polly, Newtonsoft.Json</p>
           </div>

--- a/java/README.md
+++ b/java/README.md
@@ -17,7 +17,7 @@ This project uses Java-based tools for generating REST API client code from Open
 
 **OpenAPI Generator** is a Java-based code generation tool that creates client libraries, server stubs, and API documentation from OpenAPI specifications.
 
-- **Current Version**: 7.23.0 (latest supported version)
+- **Current Version**: 7.24.0 (latest supported version)
 - **Distribution**: JAR file (`openapi-generator-cli-{version}.jar`)
 - **Download Location**: Maven Central Repository
 - **Repository**: https://github.com/OpenAPITools/openapi-generator
@@ -25,7 +25,7 @@ This project uses Java-based tools for generating REST API client code from Open
 
 **Usage in this project:**
 ```bash
-java -jar openapi-generator-cli-7.23.0.jar generate \
+java -jar openapi-generator-cli-7.24.0.jar generate \
   --generator-name csharp \
   --input-spec [swagger file] \
   --output [output directory] \

--- a/src/Core/ApiClientCodeGen.Core.Tests/Options/OpenApiGenerator/OpenApiVersionExtensionsTests.cs
+++ b/src/Core/ApiClientCodeGen.Core.Tests/Options/OpenApiGenerator/OpenApiVersionExtensionsTests.cs
@@ -57,7 +57,8 @@ public class OpenApiVersionExtensionsTests
     }
     
     [Theory]
-    [InlineData(OpenApiSupportedVersion.V7230, true)]   // Latest version
+    [InlineData(OpenApiSupportedVersion.V7240, true)]   // Latest version
+    [InlineData(OpenApiSupportedVersion.V7230, false)]  // Not latest version
     [InlineData(OpenApiSupportedVersion.V7220, false)]  // Not latest version
     [InlineData(OpenApiSupportedVersion.V7210, false)]  // Not latest version
     [InlineData(OpenApiSupportedVersion.V7200, false)]  // Not latest version
@@ -85,8 +86,9 @@ public class OpenApiVersionExtensionsTests
     [InlineData(OpenApiSupportedVersion.V7170, true)]   // Older than latest version
     [InlineData(OpenApiSupportedVersion.V7120, true)]   // Older than latest version
     [InlineData(OpenApiSupportedVersion.V7070, true)]   // Older than latest version
+    [InlineData(OpenApiSupportedVersion.V7230, true)]   // Older than latest version
     [InlineData(OpenApiSupportedVersion.V7220, true)]   // Older than latest version
-    [InlineData(OpenApiSupportedVersion.V7230, false)]  // Equal to latest version
+    [InlineData(OpenApiSupportedVersion.V7240, false)]  // Equal to latest version
     public void IsOlderThanLatest_ReturnsExpectedResult(
         OpenApiSupportedVersion currentVersion, 
         bool expectedResult)
@@ -100,6 +102,7 @@ public class OpenApiVersionExtensionsTests
 
     [Theory]
     [InlineData(OpenApiSupportedVersion.Latest, 0)]
+    [InlineData(OpenApiSupportedVersion.V7240, 7240)]
     [InlineData(OpenApiSupportedVersion.V7230, 7230)]
     [InlineData(OpenApiSupportedVersion.V7220, 7220)]
     [InlineData(OpenApiSupportedVersion.V7210, 7210)]
@@ -118,7 +121,8 @@ public class OpenApiVersionExtensionsTests
     }
 
     [Theory]
-    [InlineData(OpenApiSupportedVersion.Latest, OpenApiSupportedVersion.V7230)]
+    [InlineData(OpenApiSupportedVersion.Latest, OpenApiSupportedVersion.V7240)]
+    [InlineData(OpenApiSupportedVersion.V7240, OpenApiSupportedVersion.V7240)]
     [InlineData(OpenApiSupportedVersion.V7230, OpenApiSupportedVersion.V7230)]
     [InlineData(OpenApiSupportedVersion.V7220, OpenApiSupportedVersion.V7220)]
     [InlineData(OpenApiSupportedVersion.V7210, OpenApiSupportedVersion.V7210)]

--- a/src/Core/ApiClientCodeGen.Core/Installer/OpenApiGeneratorVersions.cs
+++ b/src/Core/ApiClientCodeGen.Core/Installer/OpenApiGeneratorVersions.cs
@@ -12,6 +12,12 @@ public static class OpenApiGeneratorVersions
     private static readonly OpenApiGeneratorVersion[] Versions =
     [
         new(
+            "7.24.0",
+            $"{DownloadUrlPrefix}/7.24.0/openapi-generator-cli-7.24.0.jar",
+            "7b5dbd235a281a0a274cc40b8b598c12c899ea85",
+            "c24f1602d6b72c44e87a1f18b90892e6"
+        ),
+        new(
             "7.23.0",
             $"{DownloadUrlPrefix}/7.23.0/openapi-generator-cli-7.23.0.jar",
             "4f4bb6d9c966a1e6353820b6e494a24269e9f2a5",

--- a/src/Core/ApiClientCodeGen.Core/Options/OpenApiGenerator/OpenApiSupportedVersion.cs
+++ b/src/Core/ApiClientCodeGen.Core/Options/OpenApiGenerator/OpenApiSupportedVersion.cs
@@ -7,11 +7,13 @@ namespace Rapicgen.Core.Options.OpenApiGenerator;
 public enum OpenApiSupportedVersion
 {
     /// <summary>
-    /// Default value that represents the latest version (maps to <see cref="V7230"/>)
+    /// Default value that represents the latest version (maps to <see cref="V7240"/>)
     /// </summary>
     [Description("Latest")]
     Latest = 0,
 
+    [Description("7.24.0")]
+    V7240 = 7240,
     [Description("7.23.0")]
     V7230 = 7230,
     [Description("7.22.0")]
@@ -53,5 +55,5 @@ public static class OpenApiSupportedVersionExtensions
     /// <summary>
     /// Gets the latest supported version of OpenAPI Generator
     /// </summary>
-    public static OpenApiSupportedVersion Latest => OpenApiSupportedVersion.V7230;
+    public static OpenApiSupportedVersion Latest => OpenApiSupportedVersion.V7240;
 }

--- a/src/Core/ApiClientCodeGen.Core/Resource.Designer.cs
+++ b/src/Core/ApiClientCodeGen.Core/Resource.Designer.cs
@@ -78,7 +78,7 @@ namespace Rapicgen.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.23.0/openapi-generator-cli-7.23.0.jar.
+        ///   Looks up a localized string similar to https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.24.0/openapi-generator-cli-7.24.0.jar.
         /// </summary>
         public static string OpenApiGenerator_DownloadUrl {
             get {
@@ -87,7 +87,7 @@ namespace Rapicgen.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 362827fb72055ecd18de886bae04bded.
+        ///   Looks up a localized string similar to c24f1602d6b72c44e87a1f18b90892e6.
         /// </summary>
         public static string OpenApiGenerator_MD5 {
             get {
@@ -96,7 +96,7 @@ namespace Rapicgen.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 4f4bb6d9c966a1e6353820b6e494a24269e9f2a5.
+        ///   Looks up a localized string similar to 7b5dbd235a281a0a274cc40b8b598c12c899ea85.
         /// </summary>
         public static string OpenApiGenerator_SHA1 {
             get {

--- a/src/Core/ApiClientCodeGen.Core/Resource.resx
+++ b/src/Core/ApiClientCodeGen.Core/Resource.resx
@@ -118,13 +118,13 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="OpenApiGenerator_DownloadUrl" xml:space="preserve">
-    <value>https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.23.0/openapi-generator-cli-7.23.0.jar</value>
+    <value>https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.24.0/openapi-generator-cli-7.24.0.jar</value>
   </data>
   <data name="OpenApiGenerator_MD5" xml:space="preserve">
-    <value>362827fb72055ecd18de886bae04bded</value>
+    <value>c24f1602d6b72c44e87a1f18b90892e6</value>
   </data>
   <data name="OpenApiGenerator_SHA1" xml:space="preserve">
-    <value>4f4bb6d9c966a1e6353820b6e494a24269e9f2a5</value>
+    <value>7b5dbd235a281a0a274cc40b8b598c12c899ea85</value>
   </data>
   <data name="SwaggerCodegenCli_DownloadUrl" xml:space="preserve">
     <value>https://repo1.maven.org/maven2/io/swagger/codegen/v3/swagger-codegen-cli/3.0.34/swagger-codegen-cli-3.0.34.jar</value>

--- a/src/IntelliJ/src/main/resources/META-INF/plugin.xml
+++ b/src/IntelliJ/src/main/resources/META-INF/plugin.xml
@@ -63,7 +63,7 @@
             <group id="ApiClientCodeGen.CSharpGroup" text="C#" popup="true">
                 <action id="ApiClientCodeGen.CSharp.NSwag" class="com.christianhelle.apiclientcodegen.actions.CSharpGeneratorNSwagAction" text="NSwag (v14.7.1)" description="Generate C# client with NSwag (v14.7.1)"/>
                 <action id="ApiClientCodeGen.CSharp.Refitter" class="com.christianhelle.apiclientcodegen.actions.CSharpGeneratorRefitterAction" text="Refitter (v2.0.0)" description="Generate C# client with Refitter (v2.0.0)"/>
-                <action id="ApiClientCodeGen.CSharp.OpenAPI" class="com.christianhelle.apiclientcodegen.actions.CSharpGeneratorOpenApiAction" text="OpenAPI Generator (v7.23.0)" description="Generate C# client with OpenAPI Generator (v7.23.0)"/>
+                <action id="ApiClientCodeGen.CSharp.OpenAPI" class="com.christianhelle.apiclientcodegen.actions.CSharpGeneratorOpenApiAction" text="OpenAPI Generator (v7.24.0)" description="Generate C# client with OpenAPI Generator (v7.24.0)"/>
                 <action id="ApiClientCodeGen.CSharp.Kiota" class="com.christianhelle.apiclientcodegen.actions.CSharpGeneratorKiotaAction" text="Microsoft Kiota (v1.34.1)" description="Generate C# client with Microsoft Kiota (v1.34.1)"/>
                 <action id="ApiClientCodeGen.CSharp.Swagger" class="com.christianhelle.apiclientcodegen.actions.CSharpGeneratorSwaggerAction" text="Swagger Codegen (v3.0.34 - Outdated)" description="Generate C# client with Swagger Codegen CLI (v3.0.34 - Outdated)"/>
             </group>

--- a/src/VSCode/package.json
+++ b/src/VSCode/package.json
@@ -36,7 +36,7 @@
       },
       {
         "command": "restApiClientCodeGenerator.openapi",
-        "title": "Generate C# Client with OpenAPI Generator (v7.23.0)"
+        "title": "Generate C# Client with OpenAPI Generator (v7.24.0)"
       },
       {
         "command": "restApiClientCodeGenerator.kiota",

--- a/src/VSIX/ApiClientCodeGen.VSIX.Dev17/VSCommandTable.vsct
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Dev17/VSCommandTable.vsct
@@ -39,7 +39,7 @@
       </Button>
       <Button guid="guidPackageCmdSet" id="OpenApiCodeGeneratorCustomToolSetter" priority="0x0101" type="Button">
         <Strings>
-          <ButtonText>Generate with OpenAPI Generator (v7.23.0)</ButtonText>
+          <ButtonText>Generate with OpenAPI Generator (v7.24.0)</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidPackageCmdSet" id="KiotaCodeGeneratorCustomToolSetter" priority="0x0102" type="Button">
@@ -94,7 +94,7 @@
       </Button>
       <Button guid="guidNewRestApiClientCmdSet" id="GenerateWithOpenApi" priority="0x0102" type="Button">
         <Strings>
-          <ButtonText>Generate with OpenAPI Generator (v7.23.0)</ButtonText>
+          <ButtonText>Generate with OpenAPI Generator (v7.24.0)</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidNewRestApiClientCmdSet" id="GenerateWithKiota" priority="0x0103" type="Button">

--- a/src/VSIX/ApiClientCodeGen.VSIX.Extensibility/.vsextension/string-resources.json
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Extensibility/.vsextension/string-resources.json
@@ -6,7 +6,7 @@
   "RefitterSettingsCommand.DisplayName": "Generate Refitter output",
   "NSwagCommand.DisplayName": "Generate with NSwag (v14.7.1)",
   "NSwagStudioCommand.DisplayName": "Generate NSwag Studio output",
-  "OpenApiGeneratorCommand.DisplayName": "Generate with OpenAPI Generator (v7.23.0)",
+  "OpenApiGeneratorCommand.DisplayName": "Generate with OpenAPI Generator (v7.24.0)",
   "KiotaCommand.DisplayName": "Generate with Microsoft Kiota (v1.32.1)",
   "SwaggerCommand.DisplayName": "Generate with Swagger (v3.0.34 - Outdated)",
 
@@ -114,6 +114,7 @@
   "Settings.OpenApi.Version.DisplayName": "Version",
   "Settings.OpenApi.Version.Description": "The version of the generator to use",
   "Settings.OpenApi.Version.Latest": "Latest",
+  "Settings.OpenApi.Version.V7240": "7.24.0",
   "Settings.OpenApi.Version.V7230": "7.23.0",
   "Settings.OpenApi.Version.V7220": "7.22.0",
   "Settings.OpenApi.Version.V7210": "7.21.0",

--- a/src/VSIX/ApiClientCodeGen.VSIX.Extensibility/Settings/OpenApiGeneratorSettings.cs
+++ b/src/VSIX/ApiClientCodeGen.VSIX.Extensibility/Settings/OpenApiGeneratorSettings.cs
@@ -141,6 +141,7 @@ internal static class OpenApiGeneratorSettings
         OpenApiGeneratorCategory,
         [
             new EnumSettingEntry("Latest", "%Settings.OpenApi.Version.Latest%"),
+            new EnumSettingEntry("V7240", "%Settings.OpenApi.Version.V7240%"),
             new EnumSettingEntry("V7230", "%Settings.OpenApi.Version.V7230%"),
             new EnumSettingEntry("V7220", "%Settings.OpenApi.Version.V7220%"),
             new EnumSettingEntry("V7210", "%Settings.OpenApi.Version.V7210%"),

--- a/src/VSIX/ApiClientCodeGen.VSIX/VSCommandTable.vsct
+++ b/src/VSIX/ApiClientCodeGen.VSIX/VSCommandTable.vsct
@@ -39,7 +39,7 @@
       </Button>
       <Button guid="guidPackageCmdSet" id="OpenApiCodeGeneratorCustomToolSetter" priority="0x0101" type="Button">
         <Strings>
-          <ButtonText>Generate with OpenAPI Generator (v7.23.0)</ButtonText>
+          <ButtonText>Generate with OpenAPI Generator (v7.24.0)</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidPackageCmdSet" id="KiotaCodeGeneratorCustomToolSetter" priority="0x0102" type="Button">
@@ -94,7 +94,7 @@
       </Button>
       <Button guid="guidNewRestApiClientCmdSet" id="GenerateWithOpenApi" priority="0x0102" type="Button">
         <Strings>
-          <ButtonText>Generate with OpenAPI Generator (v7.23.0)</ButtonText>
+          <ButtonText>Generate with OpenAPI Generator (v7.24.0)</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidNewRestApiClientCmdSet" id="GenerateWithKiota" priority="0x0103" type="Button">

--- a/src/VSMac/ApiClientCodeGen.VSMac/Properties/Manifest.addin.xml
+++ b/src/VSMac/ApiClientCodeGen.VSMac/Properties/Manifest.addin.xml
@@ -33,7 +33,7 @@
                  defaultHandler="ApiClientCodeGen.VSMac.Commands.Handlers.AddNewNSwagStudioCommandHandler" />
 
         <Command id = "ApiClientCodeGen.VSMac.Commands.AddToProject.OpenApi"
-                 _label = "Generate with OpenAPI Generator (v7.23.0)"
+                 _label = "Generate with OpenAPI Generator (v7.24.0)"
                  defaultHandler="ApiClientCodeGen.VSMac.Commands.Handlers.AddNewOpenApiCommandHandler" />
 
         <Command id = "ApiClientCodeGen.VSMac.Commands.AddToProject.Kiota"
@@ -58,7 +58,7 @@
                  defaultHandler="ApiClientCodeGen.VSMac.Commands.Handlers.GenerateNSwagStudioCommandHandler" />
 
         <Command id = "ApiClientCodeGen.VSMac.Commands.GenerateCode.OpenApi"
-                 _label = "Generate with OpenAPI Generator (v7.23.0)"
+                 _label = "Generate with OpenAPI Generator (v7.24.0)"
                  defaultHandler="ApiClientCodeGen.VSMac.Commands.Handlers.GenerateOpenApiCommandHandler" />
 
         <Command id = "ApiClientCodeGen.VSMac.Commands.GenerateCode.Kiota"


### PR DESCRIPTION
Update OpenAPI Generator CLI from v7.23.0 to v7.24.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for OpenAPI Generator v7.24.0.
  - Added v7.24.0 as a selectable generator version across supported integrations.
  - Updated the default “Latest” generator selection to v7.24.0.

- **Documentation**
  - Updated help text, examples, website content, and tool descriptions to display v7.24.0.
  - Refreshed download metadata and checksums for the new generator release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->