### PR TITLE
Fix IntelliJ plugin compatibility with current JetBrains IDEs

### DIFF
--- a/.github/workflows/intellij.yml
+++ b/.github/workflows/intellij.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Build IntelliJ Plugin
         working-directory: src/IntelliJ
         run: ./gradlew buildPlugin --no-daemon
+      - name: Verify Plugin Compatibility
+        working-directory: src/IntelliJ
+        run: ./gradlew verifyPlugin --no-daemon
       - name: Archive plugin artifact
         uses: actions/upload-artifact@v7
         with:

--- a/src/IntelliJ/README.md
+++ b/src/IntelliJ/README.md
@@ -12,8 +12,8 @@ an upper bound makes newer IDEs reject the plugin as incompatible.
 ### Preview Features Implemented
 
 - Context menu on OpenAPI spec files (`.json`, `.yaml`, `.yml`):
-	- Generate C# Client (NSwag)
-	- Generate TypeScript Client (Angular)
+	- Generate C# Client with NSwag, Refitter, OpenAPI Generator, Microsoft Kiota or Swagger Codegen CLI
+	- Generate TypeScript Client for Angular, Aurelia, Axios, Fetch, Inversify, jQuery, NestJS, Node, Redux Query or RxJS
 - Context menu on `.refitter` files: Generate Refitter Output (Refit interface + contracts)
 - Prompts for namespace (C#) or output folder (TypeScript)
 - Uses installed `rapicgen` .NET tool; shows guidance if missing

--- a/src/IntelliJ/README.md
+++ b/src/IntelliJ/README.md
@@ -1,6 +1,13 @@
 ## REST API Client Code Generator (IntelliJ / Rider Plugin)
 
-Early preview plugin providing similar code generation features as the VS Code extension, inside JetBrains IDEs (target Rider 2025.1.5).
+Early preview plugin providing similar code generation features as the VS Code extension, inside JetBrains IDEs.
+
+### IDE Compatibility
+
+The plugin is built against IntelliJ Platform 2025.1 and declares `since-build=251` with no
+upper bound, so it loads in any 2025.1 or newer JetBrains IDE (Rider included). Do not set
+`pluginUntilBuild` in `gradle.properties` unless you deliberately want to cap compatibility --
+an upper bound makes newer IDEs reject the plugin as incompatible.
 
 ### Preview Features Implemented
 
@@ -19,6 +26,15 @@ Early preview plugin providing similar code generation features as the VS Code e
 
 ```powershell
 ./gradlew buildPlugin
+```
+
+### Verify IDE Compatibility
+
+Runs the JetBrains Plugin Verifier against the recommended IDEs plus the Rider release named by
+`riderVersion` in `gradle.properties`. This is what catches "the plugin won't load in my IDE".
+
+```powershell
+./gradlew verifyPlugin
 ```
 
 ### Run Sandbox

--- a/src/IntelliJ/build-intellij.ps1
+++ b/src/IntelliJ/build-intellij.ps1
@@ -16,7 +16,8 @@ function Get-JavaMajorVersion([string]$javaHome) {
 
 function Use-Jdk21 {
 	$candidatePaths = @()
-	$candidatePaths += (Resolve-Path -ErrorAction SilentlyContinue "$PSScriptRoot/../java" | ForEach-Object { (Get-ChildItem $_.Path -Directory -ErrorAction SilentlyContinue) }) | ForEach-Object { $_.FullName }
+	# Downloaded JDKs are extracted to ../java/jdk21-extracted/<guid>/<jdk>, so search that deep
+	$candidatePaths += (Get-ChildItem "$PSScriptRoot/../java" -Directory -Recurse -Depth 2 -ErrorAction SilentlyContinue) | ForEach-Object { $_.FullName }
 	if ($env:JAVA_HOME) { $candidatePaths += $env:JAVA_HOME }
 	if ($env:JDK_HOME) { $candidatePaths += $env:JDK_HOME }
 	$candidatePaths += (Get-ChildItem "$Env:ProgramFiles/Java" -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName)

--- a/src/IntelliJ/build-intellij.ps1
+++ b/src/IntelliJ/build-intellij.ps1
@@ -82,5 +82,14 @@ if (-not (Get-Command java -ErrorAction SilentlyContinue)) {
 }
 
 Write-Host "Gradle using java from: $($env:JAVA_HOME)" -ForegroundColor Yellow
-./gradlew --version
-./gradlew buildPlugin
+# Resolve gradlew against the script's directory, not the caller's working directory
+Push-Location $PSScriptRoot
+try {
+	./gradlew --version
+	./gradlew buildPlugin
+	$buildExitCode = $LASTEXITCODE
+}
+finally {
+	Pop-Location
+}
+exit $buildExitCode

--- a/src/IntelliJ/build.gradle.kts
+++ b/src/IntelliJ/build.gradle.kts
@@ -30,6 +30,11 @@ intellijPlatform {
         ideaVersion.sinceBuild.set(pluginSinceBuild)
         if (pluginUntilBuild.isNotBlank()) {
             ideaVersion.untilBuild.set(pluginUntilBuild)
+        } else {
+            // Drop the until-build attribute entirely. Without this the platform
+            // defaults it to the build-time branch, which makes newer IDEs (Rider
+            // 2026.2, for example) reject the plugin as incompatible.
+            ideaVersion.untilBuild.set(provider { null })
         }
     }
     pluginVerification {

--- a/src/IntelliJ/build.gradle.kts
+++ b/src/IntelliJ/build.gradle.kts
@@ -11,6 +11,7 @@ val pluginSinceBuild: String by project
 val pluginUntilBuild: String by project
 val platformVersion: String by project
 val javaVersion: String by project
+val kotlinApiVersion: String by project
 
 group = pluginGroup
 version = pluginVersion
@@ -64,6 +65,9 @@ kotlin {
     jvmToolchain(javaVersion.toInt())
     compilerOptions {
         jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.valueOf("JVM_${javaVersion}"))
+        // The IDE supplies the Kotlin stdlib at runtime, so never compile against
+        // stdlib APIs newer than the oldest platform we claim to support.
+        apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion(kotlinApiVersion))
     }
 }
 

--- a/src/IntelliJ/build.gradle.kts
+++ b/src/IntelliJ/build.gradle.kts
@@ -10,6 +10,7 @@ val pluginVersion: String by project
 val pluginSinceBuild: String by project
 val pluginUntilBuild: String by project
 val platformVersion: String by project
+val riderVersion: String by project
 val javaVersion: String by project
 val kotlinApiVersion: String by project
 
@@ -41,6 +42,8 @@ intellijPlatform {
     pluginVerification {
         ides {
             recommended()
+            // Most users run this plugin in Rider, so verify against it explicitly
+            create(org.jetbrains.intellij.platform.gradle.IntelliJPlatformType.Rider, riderVersion)
         }
     }
 }

--- a/src/IntelliJ/gradle.properties
+++ b/src/IntelliJ/gradle.properties
@@ -11,7 +11,6 @@ javaVersion=21
 # Must match the Kotlin stdlib bundled with the oldest supported platform
 # (2025.1 ships 2.1.10), since the plugin does not bundle its own stdlib.
 kotlinApiVersion=2.1
-gradleVersion=8.7
 org.gradle.jvmargs=-Xmx2g -Djansi.ignore=true
 org.gradle.java.installations.auto-download=true
 org.gradle.java.installations.auto-detect=true

--- a/src/IntelliJ/gradle.properties
+++ b/src/IntelliJ/gradle.properties
@@ -6,6 +6,9 @@ pluginUntilBuild=
 platformVersion=2025.1
 platformPlugins=
 javaVersion=21
+# Must match the Kotlin stdlib bundled with the oldest supported platform
+# (2025.1 ships 2.1.10), since the plugin does not bundle its own stdlib.
+kotlinApiVersion=2.1
 gradleVersion=8.7
 org.gradle.jvmargs=-Xmx2g -Djansi.ignore=true
 org.gradle.java.installations.auto-download=true

--- a/src/IntelliJ/gradle.properties
+++ b/src/IntelliJ/gradle.properties
@@ -4,6 +4,8 @@ pluginVersion=0.1.0
 pluginSinceBuild=251
 pluginUntilBuild=
 platformVersion=2025.1
+# Rider release the plugin is verified against, in addition to the recommended IDEs
+riderVersion=2026.2
 platformPlugins=
 javaVersion=21
 # Must match the Kotlin stdlib bundled with the oldest supported platform

--- a/src/IntelliJ/src/main/resources/META-INF/plugin.xml
+++ b/src/IntelliJ/src/main/resources/META-INF/plugin.xml
@@ -54,8 +54,6 @@
         
         <p>🔗 <a href="https://github.com/christianhelle/apiclientcodegen">GitHub Repository</a> | <a href="https://marketplace.visualstudio.com/items?itemName=ChristianResmaHelle.ApiClientCodeGenerator2022">VS Extension</a> | <a href="https://marketplace.visualstudio.com/items?itemName=ChristianResmaHelle.apiclientcodegen">VS Code Extension</a></p>
     ]]></description>
-    <version>${pluginVersion}</version>
-    <idea-version since-build="${pluginSinceBuild}" until-build="${pluginUntilBuild}"/>
     <depends>com.intellij.modules.platform</depends>
     <actions>
         <group id="ApiClientCodeGen.Group" text="REST API Client Code Generator" popup="true">


### PR DESCRIPTION
## Problem

The plugin does not load in Rider 2026.2 (`RD-262.9437.287`). The installed artifact declares:

```
<idea-version since-build="251" until-build="261.*" />
Platform-Version: 2025.1   Kotlin-Stdlib-Bundled: true   Kotlin-Version: 2.0.0
```

`262 > 261.*`, so Rider marks it incompatible and never loads it. That artifact predates 442d2e7 (which blanked `pluginUntilBuild`), so a current build already loads — but the source was one IPGP default away from reintroducing the same cap, and carried a separate runtime hazard.

## What changed

**The `until-build` cap could come back.** `plugin.xml` hardcoded `until-build="${pluginUntilBuild}"`; the attribute only vanished because Gradle could not resolve the placeholder. And the blank-`pluginUntilBuild` branch in `build.gradle.kts` did nothing — it fell through to the platform default of `<build-time branch>.*`. The placeholders are gone (`patchPluginXml` now owns `<version>` and `<idea-version>`), and the blank case explicitly clears the property via `untilBuild.set(provider { null })`.

**Kotlin API level was unpinned.** `kotlin.stdlib.default.dependency=false` means the IDE supplies the stdlib at runtime, and IC 2025.1 ships 2.1.10 — but the plugin compiled with Kotlin 2.4.10. Any stdlib API added after 2.1 would compile cleanly and throw `NoSuchMethodError` in the IDE. Pinned `apiVersion` to a new `kotlinApiVersion=2.1` property. (`languageVersion` is deliberately left at the default; pinning it only produced a deprecation warning without adding safety.)

**Nothing verified against Rider.** `pluginVerification` listed only `recommended()`, which resolves IntelliJ IDEA Community releases — the one IDE most of this plugin's users are not running. Added an explicit Rider target driven by a new `riderVersion` property, and wired `verifyPlugin` into `.github/workflows/intellij.yml`.

Also: corrected the README (it claimed "target Rider 2025.1.5" and listed 2 of the 15 generators actually in `plugin.xml`) and dropped the unused `gradleVersion=8.7`, which contradicted the 9.4.1 wrapper.

## Verification

`./gradlew clean buildPlugin verifyPlugin` — JetBrains Plugin Verifier, all three targets:

```
RD-262.8665.328  : Compatible
IC-252.28539.97  : Compatible
IC-251.29188.72  : Compatible
```

The emitted descriptor is now `<idea-version since-build="251" />` with no upper bound, and `Kotlin-Stdlib-Bundled: false`.

## Notes for reviewers

- **CI runtime increases.** `verifyPlugin` downloads three IDEs (~3 GB, ~2 min with a warm cache). The `~/.gradle/caches` cache in the workflow covers the download, but the first run on a cold cache will be slow. Drop the step if that trade-off is not worth it.
- `riderVersion=2026.2` is a manual pin and will need bumping as Rider advances. `recommended()` drifts automatically; this one does not.
- Anyone currently running the plugin in a 2026.x IDE needs to reinstall from a fresh build — this PR cannot un-cap an already-installed jar.
- Commits are sliced one logical change each, so the diff reads cleanly commit by commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Compatibility**
  - Updated the IntelliJ plugin to support IntelliJ Platform 2025.1 and later, including Rider.
  - Improved compatibility verification across supported IDE versions.

- **Preview Features**
  - Expanded supported C# generators to include Refitter, OpenAPI Generator, Microsoft Kiota, and Swagger Codegen CLI.
  - Expanded supported TypeScript generators to include Aurelia, Axios, Fetch, Inversify, jQuery, NestJS, Node, Redux Query, and RxJS.

- **Build Verification**
  - Added automated checks to confirm plugin compatibility before release artifacts are archived.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Build script fix (`build-intellij.ps1`)

Found while verifying: the helper script failed when run from anywhere except `src/IntelliJ`. This was pre-existing — the identical failure reproduces on `031b7f05e` — but neither the original verification nor CI exercised the script (CI calls `./gradlew` directly), so it went unnoticed.

- **`./gradlew` resolved against the caller's cwd.** Run from the repo root it failed with `The term './gradlew' is not recognized`. Gradle now runs from `$PSScriptRoot`, and the script exits with `buildPlugin`'s exit code explicitly (previously it did so only because that call happened to be last).
- **Every run re-downloaded the 200 MB JDK.** `Use-Jdk21` scanned only the direct children of `src/java`, never the extracted JDK at `jdk21-extracted/<guid>/<jdk>`, so detection always missed and the download path wiped and re-extracted the cache each run.

Verified by running the script itself:

| run | result |
|---|---|
| from repo root, `build/` deleted | BUILD SUCCESSFUL, 10 tasks executed, exit 0, no download |
| from an unrelated directory | exit 0, no download |
| forced Gradle failure (`javaVersion=999`) | BUILD FAILED, exit 1 |

Built descriptor: `<idea-version since-build="251" />`.
