### PR TITLE
Bump Refit to 10.2.0 to fix the revoked-certificate restore failure

### DIFF
--- a/test/GeneratedCode/Refitter/Net462/Net462.csproj
+++ b/test/GeneratedCode/Refitter/Net462/Net462.csproj
@@ -16,7 +16,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Refit" Version="10.1.6" />
+    <PackageReference Include="Refit" Version="10.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />

--- a/test/GeneratedCode/Refitter/Net472/Net472.csproj
+++ b/test/GeneratedCode/Refitter/Net472/Net472.csproj
@@ -16,7 +16,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Refit" Version="10.1.6" />
+    <PackageReference Include="Refit" Version="10.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />

--- a/test/GeneratedCode/Refitter/Net48/Net48.csproj
+++ b/test/GeneratedCode/Refitter/Net48/Net48.csproj
@@ -16,7 +16,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Refit" Version="10.1.6" />
+    <PackageReference Include="Refit" Version="10.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />

--- a/test/GeneratedCode/Refitter/Net481/Net481.csproj
+++ b/test/GeneratedCode/Refitter/Net481/Net481.csproj
@@ -16,7 +16,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Refit" Version="10.1.6" />
+    <PackageReference Include="Refit" Version="10.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />

--- a/test/GeneratedCode/Refitter/Net6/Net6.csproj
+++ b/test/GeneratedCode/Refitter/Net6/Net6.csproj
@@ -4,7 +4,7 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Refit" Version="10.1.6" />
+    <PackageReference Include="Refit" Version="10.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />

--- a/test/GeneratedCode/Refitter/Net7/Net7.csproj
+++ b/test/GeneratedCode/Refitter/Net7/Net7.csproj
@@ -4,7 +4,7 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Refit" Version="10.1.6" />
+    <PackageReference Include="Refit" Version="10.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />

--- a/test/GeneratedCode/Refitter/Net8/Net8.csproj
+++ b/test/GeneratedCode/Refitter/Net8/Net8.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Refit" Version="10.1.6" />
+    <PackageReference Include="Refit" Version="10.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />

--- a/test/GeneratedCode/Refitter/Net9/Net9.csproj
+++ b/test/GeneratedCode/Refitter/Net9/Net9.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Refit" Version="10.1.6" />
+    <PackageReference Include="Refit" Version="10.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />

--- a/test/GeneratedCode/Refitter/NetStandard20/NetStandard20.csproj
+++ b/test/GeneratedCode/Refitter/NetStandard20/NetStandard20.csproj
@@ -4,7 +4,7 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Refit" Version="10.1.6" />
+    <PackageReference Include="Refit" Version="10.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />

--- a/test/GeneratedCode/Refitter/NetStandard21/NetStandard21.csproj
+++ b/test/GeneratedCode/Refitter/NetStandard21/NetStandard21.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Refit" Version="10.1.6" />
+    <PackageReference Include="Refit" Version="10.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />


### PR DESCRIPTION
## Problem

`submit-nuget` (Automatic Dependency Submission) has failed on every branch since 2026-09-04:

```
test/GeneratedCode/Refitter/Net9/Net9.csproj : error NU3012: Package 'Refit 10.1.6' from source 'https://api.nuget.org/v3/index.json':
The author primary signature found a chain building issue: Revoked: certificate revoked
```

The certificate that signed Refit 10.1.6 (`CN=Glenn Watson`, valid 2026-02-21 to 2027-02-20) was revoked. Refit's maintainers unlisted 10.1.6 (and 10.1.7) and re-released it: the [v10.2.0 release notes](https://github.com/reactiveui/refit/releases/tag/v10.2.0) state "This is a re-release of v10.1.6 which had a certificate revoked" (see reactiveui/refit#2114).

## Change

Refit `10.1.6` → `10.2.0` in the 10 Refitter smoke-test projects under `test/GeneratedCode/Refitter/`. Nothing else.

## Why 10.2.0 rather than the latest

- **New certificate.** 10.2.0 is signed with `CN=Glenn Andrew Watson`, valid from 2026-05-23, not the revoked one.
- **Same target frameworks as 10.1.6** (`net462`, `netstandard2.0`, `net8.0`–`net10.0`). Refit 12.0.0 and later drop `netstandard2.0`, which the NetStandard20, NetStandard21, Net6 and Net7 projects resolve against.
- **Same major version.** Renovate's Refit v15 PR (#1648) was closed without merging after its `C# (json|yaml, V2|V3)` checks failed, and Renovate now ignores 15.x.

## Verification

**Restore on Linux, matching CI.** Ubuntu 24.04, .NET SDK 10.0.401 (`mcr.microsoft.com/dotnet/sdk:10.0`), empty package folder per run:

| Refit | result |
|---|---|
| 10.1.6 (before) | all 10 projects fail with `NU3012`, reproducing CI |
| 10.2.0 (after) | all 10 projects restore |

Windows does not reproduce the `NU3012` (10.1.6 restores fine there), so the Linux run is the meaningful one.

**Generated code still compiles.** Replicated `smoke-tests.yml` locally: generated code with the CLI (Refitter v2.1.3) for all four specs (V2/V3 × json/yaml) and built all 10 projects for each. 40/40 builds succeeded, and every project resolved `Refit/10.2.0`. Smoke Tests also run in CI on this PR, since csproj changes under `test/GeneratedCode` trigger them.

## Notes for reviewers

- Other open branches (for example #1664) will keep failing `submit-nuget` until they pick up this change from `master`.
- The CLI targets `net8.0`; locally I ran it on the .NET 9/10 runtime with `DOTNET_ROLL_FORWARD=Major`. CI's Smoke Tests run it on .NET 8.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Refit package from version 10.1.6 to 10.2.0 across supported test targets, including .NET Framework, .NET, and .NET Standard configurations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->